### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/wafo/bitwise.py
+++ b/wafo/bitwise.py
@@ -87,7 +87,7 @@ def setbits(bitlist):
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 if __name__ == '__main__':

--- a/wafo/containers.py
+++ b/wafo/containers.py
@@ -268,7 +268,7 @@ class AxisLabels:
         return self.__str__()
 
     def __str__(self):
-        return '%s\n%s\n%s\n%s\n' % (
+        return '{0!s}\n{1!s}\n{2!s}\n{3!s}\n'.format(
             self.title, self.xlab, self.ylab, self.zlab)
 
     def copy(self):
@@ -603,7 +603,7 @@ def test_plotdata():
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 

--- a/wafo/dctpack.py
+++ b/wafo/dctpack.py
@@ -426,7 +426,7 @@ def test_dct2():
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 

--- a/wafo/demos.py
+++ b/wafo/demos.py
@@ -131,7 +131,7 @@ def humps(x=None):
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 if __name__ == '__main__':

--- a/wafo/doc/tutorial_scripts/chapter2.py
+++ b/wafo/doc/tutorial_scripts/chapter2.py
@@ -46,7 +46,7 @@ show()
 #! crossing intensity curve, as follows.  
 T = xx[:, 0].max() - xx[:, 0].min()
 f0 = np.interp(0, lc.args, lc.data, 0) / T  #! zero up-crossing frequency 
-print('f0 = %g' % f0)
+print('f0 = {0:g}'.format(f0))
 
 #! Turningpoints and irregularity factor
 #!----------------------------------------
@@ -54,7 +54,7 @@ print('f0 = %g' % f0)
 fm = len(tp.data) / (2 * T)   # frequency of maxima
 alfa = f0 / fm                # approx Tm24/Tm02
 
-print('fm = %g, alpha = %g, ' % (fm, alfa))
+print('fm = {0:g}, alpha = {1:g}, '.format(fm, alfa))
 
 #! Visually examine data
 #!------------------------
@@ -101,7 +101,7 @@ show()
 #! Calculate moments  
 #!-------------------
 mom, text = S.moment(nr=4)
-print('sigma = %g, m0 = %g' % (sa, sqrt(mom[0])))
+print('sigma = {0:g}, m0 = {1:g}'.format(sa, sqrt(mom[0])))
 
 #! Section 2.2.1 Random functions in Spectral Domain - Gaussian processes
 #!--------------------------------------------------------------------------

--- a/wafo/doc/tutorial_scripts/chapter4.py
+++ b/wafo/doc/tutorial_scripts/chapter4.py
@@ -54,7 +54,7 @@ m_sea = ts.data.mean()
 f0_sea = interp(m_sea, lc.args,lc.data)
 extr_sea = len(tp.data)/(2*T_sea)
 alfa_sea = f0_sea/extr_sea
-print('alfa = %g ' % alfa_sea )
+print('alfa = {0:g} '.format(alfa_sea) )
 
 #! Section 4.3.2 Extraction of rainflow cycles
 #!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/wafo/fig.py
+++ b/wafo/fig.py
@@ -144,7 +144,7 @@ def _fig2wnd(figs):
     global _FIG_FORMATS
     for fig in figs:
         for format_ in _FIG_FORMATS:
-            winTitle = format_ + ' %d' % fig
+            winTitle = format_ + ' {0:d}'.format(fig)
             hwnd = FindWindow(None, winTitle)
             if not hwnd == 0:
                 wnd_handles.append(hwnd)
@@ -185,7 +185,7 @@ def _show_figure(figs, cmdshow):
     global _FIG_FORMATS
     for fig in figs:
         for format_ in _FIG_FORMATS:
-            winTitle = format_ + ' %d' % fig
+            winTitle = format_ + ' {0:d}'.format(fig)
             hwnd = FindWindow(None, winTitle)
             if not hwnd == 0:
                 #ShowWindow(hwnd,cmdshow)
@@ -527,7 +527,7 @@ def stack(*figs):
         maxfigs = numpy.fix(screenpos[3] / 20)
 
         if (numfigs > maxfigs):            # figure limit check
-            print(' More than %d requested ' % maxfigs)
+            print(' More than {0:d} requested '.format(maxfigs))
             return
         BringWindowToTop = win32gui.BringWindowToTop
         MoveWindow = win32gui.MoveWindow

--- a/wafo/gaussian.py
+++ b/wafo/gaussian.py
@@ -601,8 +601,7 @@ def prbnormndpc(rho, a, b, abserr=1e-4, relerr=1e-4, usesimpson=True,
     val, err, ier = mvnprdmod.prbnormndpc(rho, a, b, abserr, relerr, usebreakpoints, usesimpson)  # @UndefinedVariable @IgnorePep8
 
     if ier > 0:
-        warnings.warn('Abnormal termination ier = %d\n\n%s' %
-                      (ier, _ERRORMESSAGE[ier]))
+        warnings.warn('Abnormal termination ier = {0:d}\n\n{1!s}'.format(ier, _ERRORMESSAGE[ier]))
     return val, err, ier
 
 _ERRORMESSAGE = {}

--- a/wafo/graphutil.py
+++ b/wafo/graphutil.py
@@ -47,7 +47,7 @@ def delete_text_object(gidtxt, figure=None, axis=None, verbose=False):
         except:
             if verbose:
                 warnings.warn(
-                    'Tried to delete a non-existing %s from axis' % gidtxt)
+                    'Tried to delete a non-existing {0!s} from axis'.format(gidtxt))
     objs = figure.findobj(lmatchfun)
     for obj in objs:
         try:
@@ -55,7 +55,7 @@ def delete_text_object(gidtxt, figure=None, axis=None, verbose=False):
         except:
             if verbose:
                 warnings.warn(
-                    'Tried to delete a non-existing %s from figure' % gidtxt)
+                    'Tried to delete a non-existing {0!s} from figure'.format(gidtxt))
 
 
 def cltext(levels, percent=False, n=4, xs=0.036, ys=0.94, zs=0, figure=None,
@@ -135,7 +135,7 @@ def cltext(levels, percent=False, n=4, xs=0.036, ys=0.94, zs=0, figure=None,
     else:
         titletxt = 'Level curves at:'
 
-    format_ = '%0.' + ('%d' % n) + 'g\n'
+    format_ = '%0.' + ('{0:d}'.format(n)) + 'g\n'
 
     cltxt = ''.join([format_ % level for level in clevels.tolist()])
 
@@ -260,7 +260,7 @@ def _find_mid_points(x):
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 if __name__ == '__main__':

--- a/wafo/integrate.py
+++ b/wafo/integrate.py
@@ -959,7 +959,7 @@ class _Gaussq(object):
 
     def _points_and_weights(self, gn, wfun, alpha, beta):
         global _POINTS_AND_WEIGHTS
-        name = 'wfun%d_%d_%g_%g' % (wfun, gn, alpha, beta)
+        name = 'wfun{0:d}_{1:d}_{2:g}_{3:g}'.format(wfun, gn, alpha, beta)
         x_and_w = _POINTS_AND_WEIGHTS.setdefault(name, [])
         if len(x_and_w) == 0:
             x_and_w.extend(qrule(gn, wfun, alpha, beta))
@@ -999,7 +999,7 @@ class _Gaussq(object):
             if (nk == np.prod(a_shape)):
                 tmptxt = 'All integrals did not converge'
             else:
-                tmptxt = '%d integrals did not converge' % (nk, )
+                tmptxt = '{0:d} integrals did not converge'.format(nk )
             tmptxt = tmptxt + '--singularities likely!'
         else:
             tmptxt = 'Integral did not converge--singularity likely!'
@@ -1304,7 +1304,7 @@ def qdemo(f, a, b, kmax=9, plot_error=False):
      513, 19.0855369233, 0.0000000001, 19.0855915273, 0.0000546041
     '''
     true_val, _tol = intg.quad(f, a, b)
-    print('true value = %12.8f' % (true_val,))
+    print('true value = {0:12.8f}'.format(true_val))
     neval = zeros(kmax, dtype=int)
     vals_dic = {}
     err_dic = {}
@@ -1354,7 +1354,7 @@ def qdemo(f, a, b, kmax=9, plot_error=False):
     formats[-1] = formats[-1].split(',')[0]
     formats_h = ['%4s, ', ] + ['%20s, ', ] * num_cols
     formats_h[-1] = formats_h[-1].split(',')[0]
-    headers = ['evals'] + ['%12s %12s' % ('approx', 'error')] * num_cols
+    headers = ['evals'] + ['{0:12!s} {1:12!s}'.format('approx', 'error')] * num_cols
     while len(names) > 0:
         print(''.join(fi % t for fi, t in zip(formats_h,
                                               ['ftn'] + names[:num_cols])))

--- a/wafo/interpolate.py
+++ b/wafo/interpolate.py
@@ -1258,7 +1258,7 @@ def test_pp():
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 

--- a/wafo/kdetools.py
+++ b/wafo/kdetools.py
@@ -229,7 +229,7 @@ class KDEgauss(object):
         if output == 'value':
             return f
         else:
-            titlestr = 'Kernel density estimate (%s)' % self.kernel.name
+            titlestr = 'Kernel density estimate ({0!s})'.format(self.kernel.name)
             kwds2 = dict(title=titlestr)
             kwds2['plot_kwds'] = dict(plotflag=1)
             kwds2.update(**kwds)
@@ -439,7 +439,7 @@ class _KDE(object):
         if output == 'value':
             return f
         else:
-            titlestr = 'Kernel density estimate (%s)' % self.kernel.name
+            titlestr = 'Kernel density estimate ({0!s})'.format(self.kernel.name)
             kwds2 = dict(title=titlestr)
 
             kwds2['plot_kwds'] = kwds.pop('plot_kwds', dict(plotflag=1))
@@ -933,7 +933,7 @@ class KDE(_KDE):
             warnings.warn(
                 'Numerical inaccuracy due to too low discretization. ' +
                 'Increase the discretization of the evaluation grid ' +
-                '(inc=%d)!' % inc)
+                '(inc={0:d})!'.format(inc))
             norm_fact = norm_fact0
 
         kw = kw / norm_fact
@@ -2337,12 +2337,10 @@ class Kernel(object):
             h[dim] = hvec[idx] * (STEconstant / STEconstant2) ** (1 / 5)
             if idx == 0:
                 warnings.warn(
-                    'Optimum is probably lower than hs=%g for dim=%d' %
-                    (h[dim] * s, dim))
+                    'Optimum is probably lower than hs={0:g} for dim={1:d}'.format(h[dim] * s, dim))
             elif idx == maxit - 1:
                 warnings.warn(
-                    'Optimum is probably higher than hs=%g for dim=%d' %
-                    (h[dim] * s, dim))
+                    'Optimum is probably higher than hs={0:g} for dim={1:d}'.format(h[dim] * s, dim))
 
         hvec = hvec * (STEconstant / STEconstant2) ** (1 / 5)
         if fulloutput:
@@ -3215,7 +3213,7 @@ def kde_demo1():
     for ix, h in enumerate(hVec):
         plt.figure(ix)
         kde = KDE(data, hs=h, kernel=kernel)
-        f2 = kde(x, output='plot', title='h_s = %2.2f' % h, ylab='Density')
+        f2 = kde(x, output='plot', title='h_s = {0:2.2f}'.format(h), ylab='Density')
         f2.plot('k-')
 
         plt.plot(x, st.norm.pdf(x, 0, 1), 'k:')
@@ -3241,7 +3239,7 @@ def kde_demo2():
     x = np.linspace(1.5e-2, 5, 55)
 
     kde = KDE(data)
-    f = kde(output='plot', title='Ordinary KDE (hs=%g)' % kde.hs)
+    f = kde(output='plot', title='Ordinary KDE (hs={0:g})'.format(kde.hs))
     plt.figure(0)
     f.plot()
 
@@ -3250,8 +3248,8 @@ def kde_demo2():
     # plotnorm((data).^(L2)) % gives a straight line => L2 = 0.5 reasonable
 
     tkde = TKDE(data, L2=0.5)
-    ft = tkde(x, output='plot', title='Transformation KDE (hs=%g)' %
-              tkde.tkde.hs)
+    ft = tkde(x, output='plot', title='Transformation KDE (hs={0:g})'.format(
+              tkde.tkde.hs))
     plt.figure(1)
     ft.plot()
 
@@ -3313,9 +3311,9 @@ def kde_demo4(N=50):
     f1 = kde1(output='plot', label='Ordinary KDE', plotflag=1)
 
     plt.figure(0)
-    f.plot('r', label='hns=%g' % kde.hs)
+    f.plot('r', label='hns={0:g}'.format(kde.hs))
     # plt.figure(2)
-    f1.plot('b', label='hisj=%g' % kde1.hs)
+    f1.plot('b', label='hisj={0:g}'.format(kde1.hs))
     x = np.linspace(-4, 4)
     for loc in [-5, 5]:
         plt.plot(x + loc, st.norm.pdf(x, 0, scale=1) / 2, 'k:',
@@ -3335,12 +3333,12 @@ def kde_demo5(N=500):
     data = np.hstack((st.norm.rvs(loc=5, scale=1, size=(2, N,)),
                       st.norm.rvs(loc=-5, scale=1, size=(2, N,))))
     kde = KDE(data, kernel=Kernel('gauss', 'hns'))
-    f = kde(output='plot', title='Ordinary KDE (hns=%g %g)' %
-            tuple(kde.hs.tolist()), plotflag=1)
+    f = kde(output='plot', title='Ordinary KDE (hns={0:g} {1:g})'.format(*
+            tuple(kde.hs.tolist())), plotflag=1)
 
     kde1 = KDE(data, kernel=Kernel('gauss', 'hisj'))
-    f1 = kde1(output='plot', title='Ordinary KDE (hisj=%g %g)' %
-              tuple(kde1.hs.tolist()), plotflag=1)
+    f1 = kde1(output='plot', title='Ordinary KDE (hisj={0:g} {1:g})'.format(*
+              tuple(kde1.hs.tolist())), plotflag=1)
 
     plt.figure(0)
     plt.clf()
@@ -3493,8 +3491,7 @@ def kreg_demo3(x, y, fun1, hs=None, fun='hisj', plotlog=False):
     err = (fiii - fit).std()
     f = kreg(
         xiii, output='plotobj',
-        title='%s err=%1.3f,eerr=%1.3f, n=%d, hs=%1.3f, hs1=%1.3f, hs2=%1.3f' %
-        (fun, err, eerr, n, hs, hs1, hs2), plotflag=1)
+        title='{0!s} err={1:1.3f},eerr={2:1.3f}, n={3:d}, hs={4:1.3f}, hs1={5:1.3f}, hs2={6:1.3f}'.format(fun, err, eerr, n, hs, hs1, hs2), plotflag=1)
 
     # yi[yi==0] = 1.0/(c[c!=0].min()+4)
     # yi[yi==1] = 1-1.0/(c[c!=0].min()+4)
@@ -3591,17 +3588,17 @@ def kreg_demo3(x, y, fun1, hs=None, fun='hisj', plotlog=False):
 
     # aic = averr + ((yiii-pup).clip(min=0)-(yiii-plo).clip(max=0)).sum()
 
-    fg.plot(label='KReg grid aic=%2.3f' % (aic))
-    f.plot(label='KReg averr=%2.3f ' % (averr))
-    labtxt = '%d CI' % (int(100 * (1 - alpha)))
+    fg.plot(label='KReg grid aic={0:2.3f}'.format((aic)))
+    f.plot(label='KReg averr={0:2.3f} '.format((averr)))
+    labtxt = '{0:d} CI'.format((int(100 * (1 - alpha))))
     plt.fill_between(xiii, pup, plo, alpha=0.20,
                      color='r', linestyle='--', label=labtxt)
     plt.fill_between(xiii, pup2, plo2, alpha=0.20, color='b',
-                     linestyle=':', label='%d CI2' % (int(100 * (1 - alpha))))
+                     linestyle=':', label='{0:d} CI2'.format((int(100 * (1 - alpha)))))
     plt.plot(xiii, fun1(xiii), 'r', label='True model')
     plt.scatter(xi, yi, label='data')
-    print('maxp = %g' % (np.nanmax(f.data)))
-    print('hs = %g' % (kreg.tkde.tkde.hs))
+    print('maxp = {0:g}'.format((np.nanmax(f.data))))
+    print('hs = {0:g}'.format((kreg.tkde.tkde.hs)))
     plt.legend()
     h = plt.gca()
     if plotlog:
@@ -3672,7 +3669,7 @@ def kreg_demo4(x, y, hs, hopt, alpha=0.05):
         np.abs((yiii - pup).clip(min=0) - (yiii - plo).clip(max=0)).sum()
 
     f.aicc = aicc
-    f.labels.title = 'perr=%1.3f,aicc=%1.3f, n=%d, hs=%1.3f' % (
+    f.labels.title = 'perr={0:1.3f},aicc={1:1.3f}, n={2:d}, hs={3:1.3f}'.format(
         f.prediction_error_avg, aicc, n, hs)
 
     return f
@@ -3751,7 +3748,7 @@ def check_regression_bin():
         figk = plt.figure(k)
         ax = figk.gca()
         k += 1
-        fbest.labels.title = 'N = %d' % n
+        fbest.labels.title = 'N = {0:d}'.format(n)
         fbest.plot(axis=ax)
         ax.plot(x, fun1(x), 'r')
         ax.legend(frameon=False, markerscale=4)
@@ -3781,7 +3778,7 @@ def check_bkregression():
 #        axsize = ax.axis()
 #        ax.vlines(fbest.hs,axsize[2]+1,axsize[3])
 #        ax.set(yscale='log')
-        fbest.labels.title = 'N = %d' % n
+        fbest.labels.title = 'N = {0:d}'.format(n)
         fbest.plot(axis=ax)
         ax.plot(x, fun1(x), 'r')
         ax.legend(frameon=False, markerscale=4)
@@ -3915,7 +3912,7 @@ def smoothed_bin_prb(x, y, hs, hopt, alpha=0.05, color='r', label='',
 
     f.aicc = aicc
     f.fun = kreg
-    f.labels.title = 'perr=%1.3f,aicc=%1.3f, n=%d, hs=%1.3f' % (
+    f.labels.title = 'perr={0:1.3f},aicc={1:1.3f}, n={2:d}, hs={3:1.3f}'.format(
         f.prediction_error_avg, aicc, n, hs)
 
     return f
@@ -4000,10 +3997,10 @@ def kde_gauss_demo(n=50):
     plt.show()
     print(fmax / f2.data.max())
     format_ = ''.join(('%g, ') * d)
-    format_ = 'hs0=%s hs1=%s hs2=%s' % (format_, format_, format_)
+    format_ = 'hs0={0!s} hs1={1!s} hs2={2!s}'.format(format_, format_, format_)
     print(format_ % tuple(kde0.hs.tolist() +
                           kde1.tkde.hs.tolist() + kde2.hs.tolist()))
-    print('inc0 = %d, inc1 = %d, inc2 = %d' % (kde0.inc, kde1.inc, kde2.inc))
+    print('inc0 = {0:d}, inc1 = {1:d}, inc2 = {2:d}'.format(kde0.inc, kde1.inc, kde2.inc))
 
 
 def test_kde():
@@ -4030,7 +4027,7 @@ def test_kde():
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 

--- a/wafo/misc.py
+++ b/wafo/misc.py
@@ -817,7 +817,7 @@ def findcross(x, v=0.0, kind=None):
     xn = np.int8(sign(atleast_1d(x).ravel() - v))  # @UndefinedVariable
     ind = _findcross(xn)
     if ind.size == 0:
-        warnings.warn('No level v = %0.5g crossings found in x' % v)
+        warnings.warn('No level v = {0:0.5g} crossings found in x'.format(v))
         return ind
 
     if kind not in ('du', 'all', None):
@@ -1363,7 +1363,7 @@ def rfcfilter(x, h, method=0):
                   ((z0 == -1) & cmpfun1(fpi, yi))):
                 z1 = +1
             else:
-                warnings.warn('Something wrong, i=%d' % tim1)
+                warnings.warn('Something wrong, i={0:d}'.format(tim1))
 
             # Update y1
             if z1 != z0:
@@ -1666,18 +1666,18 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
     if findNaN and indmiss.any():
         ind, = nonzero(indmiss)
         if verbose:
-            print('Found %d missing points' % ind.size)
+            print('Found {0:d} missing points'.format(ind.size))
         xn[indmiss] = 0.  # %set NaN's to zero
 
     if dcrit is None:
         dcrit = 1.5 * xn.std()
         if verbose:
-            print('dcrit is set to %g' % dcrit)
+            print('dcrit is set to {0:g}'.format(dcrit))
 
     if ddcrit is None:
         ddcrit = 1.5 * xn.std()
         if verbose:
-            print('ddcrit is set to %g' % ddcrit)
+            print('ddcrit is set to {0:g}'.format(ddcrit))
 
     dxn = diff(xn)
     ddxn = diff(dxn)
@@ -1689,7 +1689,7 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
             tmp = tmp + 1
             ind = hstack((ind, tmp))
         if verbose:
-            print('Found %d spurious spikes' % tmp.size)
+            print('Found {0:d} spurious spikes'.format(tmp.size))
 
     if findDspikes:  # ,% finding spurious double (two point) spikes
         tmp, = nonzero((dxn[:-2] > dcrit) * (dxn[2::] < -dcrit) |
@@ -1698,18 +1698,18 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
             tmp = tmp + 1
             ind = hstack((ind, tmp, tmp + 1))  # %removing both points
         if verbose:
-            print('Found %d spurious two point (double) spikes' % tmp.size)
+            print('Found {0:d} spurious two point (double) spikes'.format(tmp.size))
 
     if findjumpsDx:  # ,% finding spurious jumps  in Dx
         tmp, = nonzero(dxn > dcrit)
         if verbose:
-            print('Found %d spurious positive jumps of Dx' % tmp.size)
+            print('Found {0:d} spurious positive jumps of Dx'.format(tmp.size))
         if tmp.size > 0:
             ind = hstack((ind, tmp + 1))  # removing the point after the jump
 
         tmp, = nonzero(dxn < -dcrit)
         if verbose:
-            print('Found %d spurious negative jumps of Dx' % tmp.size)
+            print('Found {0:d} spurious negative jumps of Dx'.format(tmp.size))
         if tmp.size > 0:
             ind = hstack((ind, tmp))  # removing the point before the jump
 
@@ -1720,7 +1720,7 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
             ind = hstack((ind, tmp))  # removing the jump
 
         if verbose:
-            print('Found %d spurious positive jumps of D^2x' % tmp.size)
+            print('Found {0:d} spurious positive jumps of D^2x'.format(tmp.size))
 
         tmp, = nonzero(ddxn < -ddcrit)
         if tmp.size > 0:
@@ -1728,7 +1728,7 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
             ind = hstack((ind, tmp))  # removing the jump
 
         if verbose:
-            print('Found %d spurious negative jumps of D^2x' % tmp.size)
+            print('Found {0:d} spurious negative jumps of D^2x'.format(tmp.size))
 
     if zcrit >= 0.0:
         # finding consecutive values less than zcrit apart.
@@ -1748,10 +1748,9 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
 
         if verbose:
             if zcrit == 0.:
-                print('Found %d consecutive equal values' % indz.size)
+                print('Found {0:d} consecutive equal values'.format(indz.size))
             else:
-                print('Found %d consecutive values less than %g apart.' %
-                      (indz.size, zcrit))
+                print('Found {0:d} consecutive values less than {1:g} apart.'.format(indz.size, zcrit))
     indg = ones(xn.size, dtype=bool)
 
     if ind.size > 1:
@@ -1760,7 +1759,7 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
     indg, = nonzero(indg)
 
     if verbose:
-        print('Found the total of %d spurious points' % ind.size)
+        print('Found the total of {0:d} spurious points'.format(ind.size))
 
     return ind, indg
 
@@ -2381,7 +2380,7 @@ def _discretize_adaptive(fun, a, b, tol=0.005, n=5):
         else:
             break
     else:
-        warnings.warn('Recursion level limit reached j=%d' % j)
+        warnings.warn('Recursion level limit reached j={0:d}'.format(j))
 
     return x, fx
 
@@ -2802,14 +2801,14 @@ def num2pistr(x, n=3):
     num = frac.numerator
     den = frac.denominator
     if (den < 10) and (num < 10) and (num != 0):
-        dtxt = '' if abs(den) == 1 else '/%d' % den
+        dtxt = '' if abs(den) == 1 else '/{0:d}'.format(den)
         if abs(num) == 1:  # % numerator
             ntxt = '-' if num == -1 else ''
         else:
-            ntxt = '%d' % num
+            ntxt = '{0:d}'.format(num)
         xtxt = ntxt + r'\pi' + dtxt
     else:
-        format = '%0.' + '%dg' % n  # @ReservedAssignment
+        format = '%0.' + '{0:d}g'.format(n)  # @ReservedAssignment
         xtxt = format % x
     return xtxt
 
@@ -3014,7 +3013,7 @@ def hyp2f1_wrong(a, b, c, z, tol=1e-13, itermax=500):
         xjm2 = xjm1
         xjm1 = xj
     else:
-        warnings.warn('Reached %d limit' % j)
+        warnings.warn('Reached {0:d} limit'.format(j))
     return h
 
 
@@ -3485,7 +3484,7 @@ main = profile_main1
 def test_docstrings():
     # np.set_printoptions(precision=6)
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 

--- a/wafo/namedtuple.py
+++ b/wafo/namedtuple.py
@@ -38,55 +38,55 @@ def namedtuple(typename, field_names, verbose=False):
         if not min(c.isalnum() or c == '_' for c in name):
             raise ValueError(
                 'Type names and field names can only contain alphanumeric ' +
-                'characters and underscores: %r' % name)
+                'characters and underscores: {0!r}'.format(name))
         if _iskeyword(name):
             raise ValueError(
-                'Type names and field names cannot be a keyword: %r' % name)
+                'Type names and field names cannot be a keyword: {0!r}'.format(name))
         if name[0].isdigit():
             raise ValueError('Type names and field names cannot start ' +
-                             'with a number: %r' % name)
+                             'with a number: {0!r}'.format(name))
     seen_names = set()
     for name in field_names:
         if name.startswith('_'):
             raise ValueError(
-                'Field names cannot start with an underscore: %r' % name)
+                'Field names cannot start with an underscore: {0!r}'.format(name))
         if name in seen_names:
-            raise ValueError('Encountered duplicate field name: %r' % name)
+            raise ValueError('Encountered duplicate field name: {0!r}'.format(name))
         seen_names.add(name)
 
     # Create and fill-in the class template
     numfields = len(field_names)
     # tuple repr without parens or quotes
     argtxt = repr(field_names).replace("'", "")[1:-1]
-    reprtxt = ', '.join('%s=%%r' % name for name in field_names)
-    dicttxt = ', '.join('%r: t[%d]' % (name, pos)
+    reprtxt = ', '.join('{0!s}=%r'.format(name) for name in field_names)
+    dicttxt = ', '.join('{0!r}: t[{1:d}]'.format(name, pos)
                         for pos, name in enumerate(field_names))
-    template = '''class %(typename)s(tuple):
-        '%(typename)s(%(argtxt)s)' \n
+    template = '''class {typename!s}(tuple):
+        '{typename!s}({argtxt!s})' \n
         __slots__ = () \n
-        _fields = %(field_names)r \n
-        def __new__(cls, %(argtxt)s):
-            return tuple.__new__(cls, (%(argtxt)s)) \n
+        _fields = {field_names!r} \n
+        def __new__(cls, {argtxt!s}):
+            return tuple.__new__(cls, ({argtxt!s})) \n
         @classmethod
         def _make(cls, iterable, new=tuple.__new__, len=len):
-            'Make a new %(typename)s object from a sequence or iterable'
+            'Make a new {typename!s} object from a sequence or iterable'
             result = new(cls, iterable)
-            if len(result) != %(numfields)d:
-                raise TypeError('Expected %(numfields)d arguments, got %%d' %% len(result))
+            if len(result) != {numfields:d}:
+                raise TypeError('Expected {numfields:d} arguments, got %d' % len(result))
             return result \n
         def __repr__(self):
-            return '%(typename)s(%(reprtxt)s)' %% self \n
+            return '{typename!s}({reprtxt!s})' % self \n
         def _asdict(t):
             'Return a new dict which maps field names to their values'
-            return {%(dicttxt)s} \n
+            return {{{dicttxt!s}}} \n
         def _replace(self, **kwds):
-            'Return a new %(typename)s object replacing specified fields with new values'
-            result = self._make(map(kwds.pop, %(field_names)r, self))
+            'Return a new {typename!s} object replacing specified fields with new values'
+            result = self._make(map(kwds.pop, {field_names!r}, self))
             if kwds:
-                raise ValueError('Got unexpected field names: %%r' %% kwds.keys())
-            return result \n\n''' % locals()
+                raise ValueError('Got unexpected field names: %r' % kwds.keys())
+            return result \n\n'''.format(**locals())
     for i, name in enumerate(field_names):
-        template += '        %s = property(itemgetter(%d))\n' % (name, i)
+        template += '        {0!s} = property(itemgetter({1:d}))\n'.format(name, i)
     if verbose:
         print template
 
@@ -122,7 +122,7 @@ if __name__ == '__main__':
             return (self.x ** 2 + self.y ** 2) ** 0.5
 
         def __str__(self):
-            return 'Point: x=%6.3f y=%6.3f hypot=%6.3f' % (self.x, self.y,
+            return 'Point: x={0:6.3f} y={1:6.3f} hypot={2:6.3f}'.format(self.x, self.y,
                                                            self.hypot)
 
     for p in Point(3, 4), Point(14, 5), Point(9. / 7, 6):

--- a/wafo/numpy_utils.py
+++ b/wafo/numpy_utils.py
@@ -824,7 +824,7 @@ def findcross(x, v=0.0, kind=None):
     xn = np.int8(sign(atleast_1d(x).ravel() - v))  # @UndefinedVariable
     ind = _findcross(xn)
     if ind.size == 0:
-        warnings.warn('No level v = %0.5g crossings found in x' % v)
+        warnings.warn('No level v = {0:0.5g} crossings found in x'.format(v))
         return ind
 
     if kind not in ('du', 'all', None):
@@ -1369,7 +1369,7 @@ def rfcfilter(x, h, method=0):
                   ((z0 == -1) & cmpfun1(fpi, yi))):
                 z1 = +1
             else:
-                warnings.warn('Something wrong, i=%d' % tim1)
+                warnings.warn('Something wrong, i={0:d}'.format(tim1))
 
             # Update y1
             if z1 != z0:
@@ -1672,18 +1672,18 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
     if findNaN and indmiss.any():
         ind, = nonzero(indmiss)
         if verbose:
-            print('Found %d missing points' % ind.size)
+            print('Found {0:d} missing points'.format(ind.size))
         xn[indmiss] = 0.  # %set NaN's to zero
 
     if dcrit is None:
         dcrit = 1.5 * xn.std()
         if verbose:
-            print('dcrit is set to %g' % dcrit)
+            print('dcrit is set to {0:g}'.format(dcrit))
 
     if ddcrit is None:
         ddcrit = 1.5 * xn.std()
         if verbose:
-            print('ddcrit is set to %g' % ddcrit)
+            print('ddcrit is set to {0:g}'.format(ddcrit))
 
     dxn = diff(xn)
     ddxn = diff(dxn)
@@ -1695,7 +1695,7 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
             tmp = tmp + 1
             ind = hstack((ind, tmp))
         if verbose:
-            print('Found %d spurious spikes' % tmp.size)
+            print('Found {0:d} spurious spikes'.format(tmp.size))
 
     if findDspikes:  # ,% finding spurious double (two point) spikes
         tmp, = nonzero((dxn[:-2] > dcrit) * (dxn[2::] < -dcrit) |
@@ -1704,18 +1704,18 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
             tmp = tmp + 1
             ind = hstack((ind, tmp, tmp + 1))  # %removing both points
         if verbose:
-            print('Found %d spurious two point (double) spikes' % tmp.size)
+            print('Found {0:d} spurious two point (double) spikes'.format(tmp.size))
 
     if findjumpsDx:  # ,% finding spurious jumps  in Dx
         tmp, = nonzero(dxn > dcrit)
         if verbose:
-            print('Found %d spurious positive jumps of Dx' % tmp.size)
+            print('Found {0:d} spurious positive jumps of Dx'.format(tmp.size))
         if tmp.size > 0:
             ind = hstack((ind, tmp + 1))  # removing the point after the jump
 
         tmp, = nonzero(dxn < -dcrit)
         if verbose:
-            print('Found %d spurious negative jumps of Dx' % tmp.size)
+            print('Found {0:d} spurious negative jumps of Dx'.format(tmp.size))
         if tmp.size > 0:
             ind = hstack((ind, tmp))  # removing the point before the jump
 
@@ -1726,7 +1726,7 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
             ind = hstack((ind, tmp))  # removing the jump
 
         if verbose:
-            print('Found %d spurious positive jumps of D^2x' % tmp.size)
+            print('Found {0:d} spurious positive jumps of D^2x'.format(tmp.size))
 
         tmp, = nonzero(ddxn < -ddcrit)
         if tmp.size > 0:
@@ -1734,7 +1734,7 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
             ind = hstack((ind, tmp))  # removing the jump
 
         if verbose:
-            print('Found %d spurious negative jumps of D^2x' % tmp.size)
+            print('Found {0:d} spurious negative jumps of D^2x'.format(tmp.size))
 
     if zcrit >= 0.0:
         # finding consecutive values less than zcrit apart.
@@ -1754,10 +1754,9 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
 
         if verbose:
             if zcrit == 0.:
-                print('Found %d consecutive equal values' % indz.size)
+                print('Found {0:d} consecutive equal values'.format(indz.size))
             else:
-                print('Found %d consecutive values less than %g apart.' %
-                      (indz.size, zcrit))
+                print('Found {0:d} consecutive values less than {1:g} apart.'.format(indz.size, zcrit))
     indg = ones(xn.size, dtype=bool)
 
     if ind.size > 1:
@@ -1766,7 +1765,7 @@ def findoutliers(x, zcrit=0.0, dcrit=None, ddcrit=None, verbose=False):
     indg, = nonzero(indg)
 
     if verbose:
-        print('Found the total of %d spurious points' % ind.size)
+        print('Found the total of {0:d} spurious points'.format(ind.size))
 
     return ind, indg
 
@@ -2275,7 +2274,7 @@ def _discretize_adaptive(fun, a, b, tol=0.005, n=5):
         else:
             break
     else:
-        warnings.warn('Recursion level limit reached j=%d' % j)
+        warnings.warn('Recursion level limit reached j={0:d}'.format(j))
 
     return x, fx
 
@@ -2697,14 +2696,14 @@ def num2pistr(x, n=3):
     num = frac.numerator
     den = frac.denominator
     if (den < 10) and (num < 10) and (num != 0):
-        dtxt = '' if abs(den) == 1 else '/%d' % den
+        dtxt = '' if abs(den) == 1 else '/{0:d}'.format(den)
         if abs(num) == 1:  # % numerator
             ntxt = '-' if num == -1 else ''
         else:
-            ntxt = '%d' % num
+            ntxt = '{0:d}'.format(num)
         xtxt = ntxt + r'\pi' + dtxt
     else:
-        format = '%0.' + '%dg' % n  # @ReservedAssignment
+        format = '%0.' + '{0:d}g'.format(n)  # @ReservedAssignment
         xtxt = format % x
     return xtxt
 
@@ -2886,7 +2885,7 @@ main = profile_main1
 def test_docstrings():
     # np.set_printoptions(precision=6)
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 if __name__ == "__main__":

--- a/wafo/objects.py
+++ b/wafo/objects.py
@@ -1234,7 +1234,7 @@ class TimeSeries(PlotData):
         elif method == 'cov':
             pass
         else:
-            raise ValueError('Unknown method (%s)' % method)
+            raise ValueError('Unknown method ({0!s})'.format(method))
 
         Be, v = self._get_bandwidth_and_dof(window, n, L, dt)
         spec.Bw = Be
@@ -1249,7 +1249,7 @@ class TimeSeries(PlotData):
         spec.tr = tr
         spec.L = L
         spec.norm = False
-        spec.note = 'method=%s' % method
+        spec.note = 'method={0!s}'.format(method)
         return spec
 
     def trdata(self, method='nonlinear', **options):
@@ -1758,10 +1758,10 @@ class TimeSeries(PlotData):
         if vh is None:
             if pdef[0] in ('m', 'M'):
                 vh = 0
-                print('   The minimum rfc height, h,  is set to: %g' % vh)
+                print('   The minimum rfc height, h,  is set to: {0:g}'.format(vh))
             else:
                 vh = x.mean()
-                print('   The level l is set to: %g' % vh)
+                print('   The level l is set to: {0:g}'.format(vh))
 
         if index is None:
             if pdef in ('m2m', 'm2M', 'M2m', 'M2M'):
@@ -2293,10 +2293,10 @@ class TimeSeries(PlotData):
                 plotbackend.plot(xi, [0, 0])
 
                 if Nwp[ix] == 1:
-                    plotbackend.ylabel('Wave %d' % wave_idx[ix])
+                    plotbackend.ylabel('Wave {0:d}'.format(wave_idx[ix]))
                 else:
                     plotbackend.ylabel(
-                        'Wave %d - %d' % (wave_idx[ix],
+                        'Wave {0:d} - {1:d}'.format(wave_idx[ix],
                                           wave_idx[ix] + Nwp[ix] - 1))
             plotbackend.xlabel('Time [sec]')
             # wafostamp
@@ -2346,7 +2346,7 @@ def main():
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 if __name__ == '__main__':

--- a/wafo/polynomial.py
+++ b/wafo/polynomial.py
@@ -643,8 +643,8 @@ def poly2hstr(p, variable='x'):
         else:
             # Append exponent if necessary.
             if ix > 1:
-                exponstr = '%.0f' % ix
-                s = '%s**%s' % (s, exponstr)
+                exponstr = '{0:.0f}'.format(ix)
+                s = '{0!s}**{1!s}'.format(s, exponstr)
                 ix = 1
             # Is it the first term?
             isfirst = s == ''
@@ -664,24 +664,24 @@ def poly2hstr(p, variable='x'):
                     s = '-'  # % Unary minus.
             else:
                 if coef < 0:
-                    s = '%s - ' % s  # % Binary minus (subtraction).
+                    s = '{0!s} - '.format(s)  # % Binary minus (subtraction).
                 else:
-                    s = '%s + ' % s  # % Binary plus (addition).
+                    s = '{0!s} + '.format(s)  # % Binary plus (addition).
 
             # Append the coefficient if it is different from one or when it is
             # the constant term.
             if needcoef:
-                coefstr = '%.20g' % abs(coef)
-                s = '%s%s' % (s, coefstr)
+                coefstr = '{0:.20g}'.format(abs(coef))
+                s = '{0!s}{1!s}'.format(s, coefstr)
 
             # Append variable if necessary.
             if needvar:
                 # Append a multiplication sign if necessary.
                 if needcoef:
                     if 1 - isfirst:
-                        s = '(%s)' % s
-                    s = '%s*' % s
-                s = '%s%s' % (s, var)
+                        s = '({0!s})'.format(s)
+                    s = '{0!s}*'.format(s)
+                s = '{0!s}{1!s}'.format(s, var)
 
     # Now treat the special case where the polynomial is zero.
     if s == '':
@@ -724,13 +724,13 @@ def poly2str(p, variable='x'):
     N = len(coeffs) - 1
 
     for k in range(len(coeffs)):
-        coefstr = '%.4g' % abs(coeffs[k])
+        coefstr = '{0:.4g}'.format(abs(coeffs[k]))
         if coefstr[-4:] == '0000':
             coefstr = coefstr[:-5]
         power = (N - k)
         if power == 0:
             if coefstr != '0':
-                newstr = '%s' % (coefstr,)
+                newstr = '{0!s}'.format(coefstr)
             else:
                 if k == 0:
                     newstr = '0'
@@ -742,23 +742,23 @@ def poly2str(p, variable='x'):
             elif coefstr == 'b' or coefstr == '1':
                 newstr = var
             else:
-                newstr = '%s*%s' % (coefstr, var)
+                newstr = '{0!s}*{1!s}'.format(coefstr, var)
         else:
             if coefstr == '0':
                 newstr = ''
             elif coefstr == 'b' or coefstr == '1':
-                newstr = '%s**%d' % (var, power,)
+                newstr = '{0!s}**{1:d}'.format(var, power)
             else:
-                newstr = '%s*%s**%d' % (coefstr, var, power)
+                newstr = '{0!s}*{1!s}**{2:d}'.format(coefstr, var, power)
 
         if k > 0:
             if newstr != '':
                 if coeffs[k] < 0:
-                    thestr = "%s - %s" % (thestr, newstr)
+                    thestr = "{0!s} - {1!s}".format(thestr, newstr)
                 else:
-                    thestr = "%s + %s" % (thestr, newstr)
+                    thestr = "{0!s} + {1!s}".format(thestr, newstr)
         elif (k == 0) and (newstr != '') and (coeffs[k] < 0):
-            thestr = "-%s" % (newstr,)
+            thestr = "-{0!s}".format(newstr)
         else:
             thestr = newstr
     return thestr
@@ -1553,7 +1553,7 @@ class Cheb1d(object):
     def __repr__(self):
         vals = repr(self.coeffs)
         vals = vals[6:-1]
-        return "Cheb1d(%s)" % vals
+        return "Cheb1d({0!s})".format(vals)
 
     def __len__(self):
         return self.order
@@ -1618,8 +1618,7 @@ class Cheb1d(object):
                 return self.__dict__[key]
             except KeyError:
                 raise AttributeError(
-                    "'%s' has no attribute '%s'" %
-                    (self.__class__, key))
+                    "'{0!s}' has no attribute '{1!s}'".format(self.__class__, key))
 
     def __getitem__(self, val):
         if val > self.order:
@@ -1826,7 +1825,7 @@ def padefitlsq(fun, m, k, a=-1, b=1, trace=False, x=None, end_points=True):
         if n < npt:
             warnings.warn(
                 'Check the result! ' +
-                'Number of function values should be at least: %d' % npt)
+                'Number of function values should be at least: {0:d}'.format(npt))
 
     if trace:
         plt.plot(x, fs, '+')
@@ -1869,7 +1868,7 @@ def padefitlsq(fun, m, k, a=-1, b=1, trace=False, x=None, end_points=True):
             c2 = cof[ncof:m:-1].tolist() + [1, ]
 
         if trace:
-            print('Iteration=%d,  max error=%g' % (ix, devmax))
+            print('Iteration={0:d},  max error={1:g}'.format(ix, devmax))
             plt.plot(x, fs, x, ee + fs)
     return poly1d(c1), poly1d(c2)
 
@@ -1948,7 +1947,7 @@ def test_polydeg():
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 
@@ -2118,7 +2117,7 @@ def chebfitnd(xi, f, deg, rcond=None, full=False, w=None):
     ndim = len(ndims)
     sizes = np.array([x.size for x in xi])
     if np.any(ndims != ndim) or z.ndim != ndim:
-        raise TypeError("expected %dD array for x1, x2,...,xn and f" % ndim)
+        raise TypeError("expected {0:d}D array for x1, x2,...,xn and f".format(ndim))
     if np.any(sizes == 0):
         raise TypeError("expected non-empty vector for xi")
 

--- a/wafo/powerpoint.py
+++ b/wafo/powerpoint.py
@@ -289,7 +289,7 @@ def rename_ppt():
                 ppt.set_footer()
                 ppt.save(os.path.join(root, ppt.footer))
             except:
-                warnings.warn('Unable to load %s' % filename)
+                warnings.warn('Unable to load {0!s}'.format(filename))
 
 
 def load_file_into_ppt():
@@ -301,7 +301,7 @@ def load_file_into_ppt():
             try:
                 unused_ppt = Powerpoint(os.path.join(root, filename))
             except:
-                warnings.warn('Unable to load %s' % filename)
+                warnings.warn('Unable to load {0!s}'.format(filename))
 if __name__ == '__main__':
     # make_ppt()
     # test_powerpoint()

--- a/wafo/sg_filter.py
+++ b/wafo/sg_filter.py
@@ -554,15 +554,15 @@ def smoothn(data, s=None, weight=None, robust=False, z0=None, tolz=1e-3,
     # Warning messages
     if isauto:
         if abs(np.log10(s) - np.log10(sMinBnd)) < errp:
-            warnings.warn('''s = %g: the lower bound for s has been reached.
-            Put s as an input variable if required.''' % s)
+            warnings.warn('''s = {0:g}: the lower bound for s has been reached.
+            Put s as an input variable if required.'''.format(s))
         elif abs(np.log10(s) - np.log10(sMaxBnd)) < errp:
-            warnings.warn('''s = %g: the Upper bound for s has been reached.
-            Put s as an input variable if required.''' % s)
+            warnings.warn('''s = {0:g}: the Upper bound for s has been reached.
+            Put s as an input variable if required.'''.format(s))
 
     if not exitflag:
-        warnings.warn('''Maximum number of iterations (%d) has been exceeded.
-        Increase MaxIter option or decrease TolZ value.''' % (maxiter))
+        warnings.warn('''Maximum number of iterations ({0:d}) has been exceeded.
+        Increase MaxIter option or decrease TolZ value.'''.format((maxiter)))
     if fulloutput:
         return z, s
     else:
@@ -1394,7 +1394,7 @@ def test_tide_filter():
     plt.plot(t, y, 'r.-', linewidth=2, label='raw data')
     # plt.plot(t, y2, 'b.-', linewidth=2, label='lowess @ %g Hz' % freq_filt)
     # plt.plot(t, y2, 'b.-', linewidth=2, label='filter @ %g Hz' % freq_filt)
-    plt.plot(t, y3, 'g.-', linewidth=2, label='filtfilt @ %g Hz' % freq_filt)
+    plt.plot(t, y3, 'g.-', linewidth=2, label='filtfilt @ {0:g} Hz'.format(freq_filt))
     plt.plot(t, y4, 'k.-', linewidth=2, label='kalman')
     # plt.plot(t, y5, 'k.', linewidth=2, label='kalman2')
     plt.plot(t, tide, 'y-', linewidth=2, label='True tide')
@@ -1434,7 +1434,7 @@ def test_hodrick_cardioid():
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 if __name__ == '__main__':

--- a/wafo/source/mreg/build_all.py
+++ b/wafo/source/mreg/build_all.py
@@ -22,8 +22,8 @@ def compile_all():
         os.system(compile1_format % file_)
     file_objects = format1 % tuple(files)
 
-    os.system(f2py_call + ' -m cov2mod  -c %s cov2mmpdfreg_intfc.f' %
-              file_objects)
+    os.system(f2py_call + ' -m cov2mod  -c {0!s} cov2mmpdfreg_intfc.f'.format(
+              file_objects))
 
 
 if __name__ == '__main__':

--- a/wafo/source/mvnprd/build_all.py
+++ b/wafo/source/mvnprd/build_all.py
@@ -14,12 +14,12 @@ def compile_all():
     compile1_format = 'gfortran -fPIC -c %s.f'
     for file_ in files:
         os.system(compile1_format % file_)
-    file_objects = '%s.o %s.o' % tuple(files)
+    file_objects = '{0!s}.o {1!s}.o'.format(*tuple(files))
 
     # os.system('f2py.py -m mvnprdmod  -c %s mvnprd_interface.f
     # --fcompiler=gnu95 --compiler=mingw32 -lmsvcr71' % file_objects)
-    os.system(f2py_call + ' -m mvnprdmod  -c %s mvnprd_interface.f ' %
-              file_objects)
+    os.system(f2py_call + ' -m mvnprdmod  -c {0!s} mvnprd_interface.f '.format(
+              file_objects))
 
 if __name__ == '__main__':
     compile_all()

--- a/wafo/source/mvnprd/setup.py
+++ b/wafo/source/mvnprd/setup.py
@@ -13,7 +13,7 @@ def compile_all():
     compile1_format = 'gfortran -fPIC -c %s.f'
     for file_ in files:
         os.system(compile1_format % file_)
-    file_objects = ['%s.o' % file_ for file_ in files]
+    file_objects = ['{0!s}.o'.format(file_) for file_ in files]
     return file_objects
 
 

--- a/wafo/source/rind2007/build_all.py
+++ b/wafo/source/rind2007/build_all.py
@@ -24,8 +24,8 @@ def compile_all():
         os.system(compile1_format % file_)
     file_objects = format1 % tuple(files)
 
-    os.system(f2py_call + ' -m rindmod  -c %s rind_interface.f ' %
-              file_objects)
+    os.system(f2py_call + ' -m rindmod  -c {0!s} rind_interface.f '.format(
+              file_objects))
 
 if __name__ == '__main__':
     compile_all()

--- a/wafo/spectrum/core.py
+++ b/wafo/spectrum/core.py
@@ -744,8 +744,8 @@ class SpecData1D(PlotData):
             lagtype = 't'
             if ftype in 'f':
                 checkdt = checkdt * 2 * pi
-        msg1 = 'Step dt = %g in computation of the density is too small.' % dt
-        msg2 = 'Step dt = %g is small, and may cause numerical inaccuracies.' % dt
+        msg1 = 'Step dt = {0:g} in computation of the density is too small.'.format(dt)
+        msg2 = 'Step dt = {0:g} is small, and may cause numerical inaccuracies.'.format(dt)
 
         if (checkdt < 2. ** -16 / dt):
             print(msg1)
@@ -1112,8 +1112,7 @@ class SpecData1D(PlotData):
                 # figtile
             # end
 
-            print('Iteration : %d, Hw12 : %g  Hw12/maxS : %g' %
-                  (ix, maxHw12, (maxHw12 / maxS)))
+            print('Iteration : {0:d}, Hw12 : {1:g}  Hw12/maxS : {2:g}'.format(ix, maxHw12, (maxHw12 / maxS)))
             if (maxHw12 < maxS * tolerance) and (Hw1[-1] < Hw2[-1]):
                 break
             # end
@@ -1200,7 +1199,7 @@ class SpecData1D(PlotData):
         # transform reference level into Gaussian level
         u = g.dat2gauss(utc)
         if verbose:
-            print('The level u for Gaussian process = %g' % u)
+            print('The level u for Gaussian process = {0:g}'.format(u))
 
         unused_t0, tn, Nt = paramt
         t = linspace(0, tn / A, Nt)  # normalized times
@@ -1396,7 +1395,7 @@ class SpecData1D(PlotData):
         else:
             xtxt = 'period [s]'
 
-        Htxt = '%s_{v =%2.5g}' % (Htxt, u)
+        Htxt = '{0!s}_{{v ={1:2.5g}}}'.format(Htxt, u)
         pdf = PlotData(f / A, t * A, title=Htxt, xlab=xtxt)
         pdf.err = err / A
         pdf.u = u
@@ -1607,7 +1606,7 @@ class SpecData1D(PlotData):
         # transform reference level into Gaussian level
         u = g.dat2gauss(utc)
         if verbose:
-            print('The level u for Gaussian process = %g' % u)
+            print('The level u for Gaussian process = {0:g}'.format(u))
 
         t0, tn, Nt = paramt
         t = linspace(0, tn / A, Nt)  # normalized times
@@ -1664,17 +1663,14 @@ class SpecData1D(PlotData):
         tmp = 'L' if in_space else 'T'
         if Nx > 2:
             titledict = {
-                '-2': 'Joint density of (Ac,At) in %s' % ptxt,
-                '-1': 'Joint density of (M,m_{rfc}) in %s' % ptxt,
-                '0': 'Joint density of (M,m) in %s' % ptxt,
-                '1': 'Joint density of (M,m,%sMm) in %s' % (tmp, ptxt),
-                '2': 'Joint density of (M,m)_{v=%2.5g} in %s' % (utc, ptxt),
-                '3': 'Joint density of (M,m,%sMm)_{v=%2.5g} in %s' %
-                (tmp, utc, ptxt),
-                '4': 'Joint density of (M,m,%sMd)_{v=%2.5g} in %s' %
-                (tmp, utc, ptxt),
-                '5': 'Joint density of (M,m,%sdm)_{v=%2.5g} in %s' %
-                (tmp, utc, ptxt)}
+                '-2': 'Joint density of (Ac,At) in {0!s}'.format(ptxt),
+                '-1': 'Joint density of (M,m_{{rfc}}) in {0!s}'.format(ptxt),
+                '0': 'Joint density of (M,m) in {0!s}'.format(ptxt),
+                '1': 'Joint density of (M,m,{0!s}Mm) in {1!s}'.format(tmp, ptxt),
+                '2': 'Joint density of (M,m)_{{v={0:2.5g}}} in {1!s}'.format(utc, ptxt),
+                '3': 'Joint density of (M,m,{0!s}Mm)_{{v={1:2.5g}}} in {2!s}'.format(tmp, utc, ptxt),
+                '4': 'Joint density of (M,m,{0!s}Md)_{{v={1:2.5g}}} in {2!s}'.format(tmp, utc, ptxt),
+                '5': 'Joint density of (M,m,{0!s}dm)_{{v={1:2.5g}}} in {2!s}'.format(tmp, utc, ptxt)}
             title = titledict[defnr]
             labx = 'Max [m]'
             laby = 'min [m]'
@@ -1682,16 +1678,16 @@ class SpecData1D(PlotData):
         else:
             note = note + 'Density is not scaled to unity'
             if defnr in (-2, -1, 0, 1):
-                title = 'Density of (%sMm, M = %2.5g, m = %2.5g)' % (
+                title = 'Density of ({0!s}Mm, M = {1:2.5g}, m = {2:2.5g})'.format(
                     tmp, h[1], h[0])
             elif defnr in (2, 3):
-                title = 'Density of (%sMm, M = %2.5g, m = %2.5g)_{v=%2.5g}' % (
+                title = 'Density of ({0!s}Mm, M = {1:2.5g}, m = {2:2.5g})_{{v={3:2.5g}}}'.format(
                     tmp, h[1], -h[1], utc)
             elif defnr == 4:
-                title = 'Density of (%sMd, %sMm, M = %2.5g, m = %2.5g)_{v=%2.5g}' % (
+                title = 'Density of ({0!s}Md, {1!s}Mm, M = {2:2.5g}, m = {3:2.5g})_{{v={4:2.5g}}}'.format(
                     tmp, tmp, h[1], -h[1], utc)
             elif defnr == 5:
-                title = 'Density of (%sdm, %sMm, M = %2.5g, m = %2.5g)_{v=%2.5g}' % (
+                title = 'Density of ({0!s}dm, {1!s}Mm, M = {2:2.5g}, m = {3:2.5g})_{{v={4:2.5g}}}'.format(
                     tmp, tmp, h[1], -h[1], utc)
 
         f = PlotData()
@@ -2892,8 +2888,7 @@ class SpecData1D(PlotData):
         f_limit_up = df * nmax
         f_limit_lo = df * nmin
         if verbose:
-            print('2nd order frequency Limits = %g,%g' %
-                  (f_limit_lo, f_limit_up))
+            print('2nd order frequency Limits = {0:g},{1:g}'.format(f_limit_lo, f_limit_up))
 
 # if nargout>3,
 # #compute the sum and frequency effects separately
@@ -3193,7 +3188,7 @@ class SpecData1D(PlotData):
                 g, _tmp = ts.trdata(method, **opt)
                 test1.append(g.dist2gauss())
             if verbose:
-                print('finished %d of %d ' % (ix + 1, rep))
+                print('finished {0:d} of {1:d} '.format(ix + 1, rep))
 
         if rep > 1:
             xs = acf.sim(ns=ns, cases=np.remainder(cases, rep))
@@ -3277,7 +3272,7 @@ class SpecData1D(PlotData):
             vari = 'x'
         S1 = abs(S) ** (j + 1.)
         m = [simps(S1, x=f)]
-        mtxt = 'm%d' % j
+        mtxt = 'm{0:d}'.format(j)
         mtext = [mtxt]
         step = mod(even, 2) + 1
         df = f ** step

--- a/wafo/spectrum/models.py
+++ b/wafo/spectrum/models.py
@@ -558,9 +558,9 @@ class Jonswap(ModelSpectrum):
         outsideJonswapRange = Tp > 5 * sqrt(Hm0) or Tp < 3.6 * sqrt(Hm0)
         if outsideJonswapRange:
             txt0 = '''
-            Hm0=%g,Tp=%g is outside the JONSWAP range.
+            Hm0={0:g},Tp={1:g} is outside the JONSWAP range.
             The validity of the spectral density is questionable.
-            ''' % (Hm0, Tp)
+            '''.format(Hm0, Tp)
             warnings.warn(txt0)
 
         if gam < 1 or 7 < gam:
@@ -1026,12 +1026,12 @@ class Torsethaugen(ModelSpectrum):
             if (3.6 * sqrt(Hm0) <= Tp & Tp <= 5 * sqrt(Hm0)):
                 print('     Jonswap range')
 
-            print('Hm0 = %g' % Hm0)
-            print('Ns, Ms = %g, %g  Nw, Mw = %g, %g' % (Ns, Ms, Nw, Mw))
-            print('gammas = %g gammaw = ' % (gammas, gammaw))
-            print('Rps = %g Rpw = %g' % (Rps, Rpw))
-            print('Hps = %g Hpw = %g' % (Hps, Hpw))
-            print('Tps = %g Tpw = %g' % (Tps, Tpw))
+            print('Hm0 = {0:g}'.format(Hm0))
+            print('Ns, Ms = {0:g}, {1:g}  Nw, Mw = {2:g}, {3:g}'.format(Ns, Ms, Nw, Mw))
+            print('gammas = {0:g} gammaw = '.format(gammas, gammaw))
+            print('Rps = {0:g} Rpw = {1:g}'.format(Rps, Rpw))
+            print('Hps = {0:g} Hpw = {1:g}'.format(Hps, Hpw))
+            print('Tps = {0:g} Tpw = {1:g}'.format(Tps, Tpw))
 
         # G0s=Ms/((Ns/Ms)**(-(Ns-1)/Ms)*gamma((Ns-1)/Ms )) #normalizing factor
         # Wind part
@@ -2097,7 +2097,7 @@ def _test_spreading():
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 

--- a/wafo/spectrum/tests/test_specdata1d.py
+++ b/wafo/spectrum/tests/test_specdata1d.py
@@ -42,14 +42,14 @@ def test_to_t_pdf():
     Sj = sm.Jonswap()
     S = Sj.tospecdata()
     f = S.to_t_pdf(pdef='Tc', paramt=(0, 10, 51), speed=7, seed=100)
-    vals = ['%2.3f' % val for val in f.data[:10]]
+    vals = ['{0:2.3f}'.format(val) for val in f.data[:10]]
     truevals = ['0.000', '0.014', '0.027', '0.040',
                 '0.050', '0.059', '0.067', '0.073', '0.077', '0.082']
     for t, v in zip(truevals, vals):
         assert(t == v)
 
     # estimated error bounds
-    vals = ['%2.4f' % val for val in f.err[:10]]
+    vals = ['{0:2.4f}'.format(val) for val in f.err[:10]]
     truevals = ['0.0000', '0.0003', '0.0003', '0.0004',
                 '0.0006', '0.0008', '0.0016', '0.0019', '0.0020', '0.0021']
     for t, v in zip(truevals, vals):

--- a/wafo/stats/_binned_statistic.py
+++ b/wafo/stats/_binned_statistic.py
@@ -267,7 +267,7 @@ def binned_statistic_dd(sample, values, statistic='mean',
     """
     if type(statistic) == str:
         if statistic not in ['mean', 'median', 'count', 'sum', 'std']:
-            raise ValueError('unrecognized statistic "%s"' % statistic)
+            raise ValueError('unrecognized statistic "{0!s}"'.format(statistic))
     elif callable(statistic):
         pass
     else:

--- a/wafo/stats/_continuous_distns.py
+++ b/wafo/stats/_continuous_distns.py
@@ -1974,7 +1974,7 @@ def _digammainv(y):
     value, _info, ier, _msg = optimize.fsolve(func, x0, xtol=1e-11,
                                               full_output=True)
     if ier != 1:
-        raise RuntimeError("_digammainv: fsolve failed, y = %r" % y)
+        raise RuntimeError("_digammainv: fsolve failed, y = {0!r}".format(y))
 
     return value[0]
 

--- a/wafo/stats/_distn_infrastructure.py
+++ b/wafo/stats/_distn_infrastructure.py
@@ -843,7 +843,7 @@ class rv_generic(object):
         tempdict['vals'] = vals
 
         if self.shapes:
-            tempdict['set_vals_stmt'] = '>>> %s = %s' % (self.shapes, vals)
+            tempdict['set_vals_stmt'] = '>>> {0!s} = {1!s}'.format(self.shapes, vals)
         else:
             tempdict['set_vals_stmt'] = ''
 
@@ -1611,7 +1611,7 @@ class rv_continuous(rv_generic):
             extradoc = ''
         if extradoc.startswith('\n\n'):
             extradoc = extradoc[2:]
-        self.__doc__ = ''.join(['%s continuous random variable.' % longname,
+        self.__doc__ = ''.join(['{0!s} continuous random variable.'.format(longname),
                                 '\n\n%(before_notes)s\n', docheaders['notes'],
                                 extradoc, '\n%(example)s'])
         self._construct_doc(docdict)
@@ -2040,8 +2040,8 @@ class rv_continuous(rv_generic):
         return self._link(x, logSF, theta, i)
 
     def _link(self, x, logSF, theta, i):
-        msg = ('Link function not implemented for the %s distribution' %
-               self.name)
+        msg = ('Link function not implemented for the {0!s} distribution'.format(
+               self.name))
         raise NotImplementedError(msg)
 
 
@@ -2303,7 +2303,7 @@ class rv_continuous(rv_generic):
         Nargs = len(args)
         fixedn = []
         index = list(range(Nargs))
-        names = ['f%d' % n for n in range(Nargs - 2)] + ['floc', 'fscale']
+        names = ['f{0:d}'.format(n) for n in range(Nargs - 2)] + ['floc', 'fscale']
         x0 = []
         for n, key in zip(index, names):
             if key in kwds:
@@ -2419,7 +2419,7 @@ class rv_continuous(rv_generic):
             try:
                 optimizer = getattr(optimize, optimizer)
             except AttributeError:
-                raise ValueError("%s is not a valid optimizer" % optimizer)
+                raise ValueError("{0!s} is not a valid optimizer".format(optimizer))
         vals = optimizer(func, x0, args=(ravel(data),), disp=0)
         if restore is not None:
             vals = restore(args, vals)
@@ -3099,7 +3099,7 @@ class rv_discrete(rv_generic):
             extradoc = ''
         if extradoc.startswith('\n\n'):
             extradoc = extradoc[2:]
-        self.__doc__ = ''.join(['%s discrete random variable.' % longname,
+        self.__doc__ = ''.join(['{0!s} discrete random variable.'.format(longname),
                                 '\n\n%(before_notes)s\n', docheaders['notes'],
                                 extradoc, '\n%(example)s'])
         self._construct_doc(docdict_discrete)

--- a/wafo/stats/_multivariate.py
+++ b/wafo/stats/_multivariate.py
@@ -53,7 +53,7 @@ def _process_parameters(dim, mean, cov):
         cov.shape = (1, 1)
 
     if mean.ndim != 1 or mean.shape[0] != dim:
-        raise ValueError("Array 'mean' must be a vector of length %d." % dim)
+        raise ValueError("Array 'mean' must be a vector of length {0:d}.".format(dim))
     if cov.ndim == 0:
         cov = cov * np.eye(dim)
     elif cov.ndim == 1:
@@ -574,7 +574,7 @@ def _dirichlet_check_parameters(alpha):
         raise ValueError("All parameters must be greater than 0")
     elif alpha.ndim != 1:
         raise ValueError("Parameter vector 'a' must be one dimensional, " +
-                         "but a.shape = %s." % str(alpha.shape))
+                         "but a.shape = {0!s}.".format(str(alpha.shape)))
     return alpha
 
 
@@ -584,8 +584,8 @@ def _dirichlet_check_input(alpha, x):
     if x.shape[0] + 1 != alpha.shape[0] and x.shape[0] != alpha.shape[0]:
         raise ValueError("Vector 'x' must have one entry less then the" +
                          " parameter vector 'a', but alpha.shape = " +
-                         "%s and " % alpha.shape +
-                         "x.shape = %s." % x.shape)
+                         "{0!s} and ".format(alpha.shape) +
+                         "x.shape = {0!s}.".format(x.shape))
 
     if x.shape[0] != alpha.shape[0]:
         xk = np.array([1 - np.sum(x, 0)])
@@ -605,7 +605,7 @@ def _dirichlet_check_input(alpha, x):
 
     if (np.abs(np.sum(x, 0) - 1.0) > 10e-10).any():
         raise ValueError("The input vector 'x' must lie within the normal " +
-                         "simplex. but sum(x)=%f." % np.sum(x, 0))
+                         "simplex. but sum(x)={0:f}.".format(np.sum(x, 0)))
 
     return x
 

--- a/wafo/stats/_numpy_compat.py
+++ b/wafo/stats/_numpy_compat.py
@@ -39,8 +39,7 @@ else:
             warnings.simplefilter('always')
             result = func(*args, **kw)
             if not len(l) > 0:
-                raise AssertionError("No warning raised when calling %s"
-                        % func.__name__)
+                raise AssertionError("No warning raised when calling {0!s}".format(func.__name__))
             if not l[0].category is warning_class:
                 raise AssertionError("First warning for %s is not a "
                         "%s( is %s)" % (func.__name__, warning_class, l[0]))

--- a/wafo/stats/core.py
+++ b/wafo/stats/core.py
@@ -136,10 +136,10 @@ def edfcnd(x, c=None, method=2):
     try:
         F = edf(z[c <= z], method=method)
     except:
-        ValueError('No data points above c=%d' % int(c))
+        ValueError('No data points above c={0:d}'.format(int(c)))
 
     if - inf < c:
-        F.labels.ylab = 'F(x| X>=%g)' % c
+        F.labels.ylab = 'F(x| X>={0:g})'.format(c)
 
     return F
 
@@ -236,7 +236,7 @@ def reslife(data, u=None, umin=None, umax=None, nu=None, nmin=3, alpha=0.05,
 
     #options.CI = [mrll,mrlu];
     #options.numdata = num;
-    titleTxt = 'Mean residual life with %d%s CI' % (100 * p, '%')
+    titleTxt = 'Mean residual life with {0:d}{1!s} CI'.format(100 * p, '%')
     res = PlotData(mrl, u, xlab='Threshold',
                    ylab='Mean Excess', title=titleTxt)
     res.workspace = dict(
@@ -390,7 +390,7 @@ def dispersion_idx(
     else:
         b_u = ok_u = None
 
-    CItxt = '%d%s CI' % (100 * p, '%')
+    CItxt = '{0:d}{1!s} CI'.format(100 * p, '%')
     titleTxt = 'Dispersion Index plot'
 
     res = PlotData(di, u, title=titleTxt,
@@ -828,11 +828,11 @@ class RegLogit(object):
             iy = np.flatnonzero(s <= tol)
             if len(ix):
                 X = X[:, ix]
-                txt = [' %d,' % i for i in iy]
+                txt = [' {0:d},'.format(i) for i in iy]
                 #txt[-1] = ' %d' % iy[-1]
                 warnings.warn(
-                    'Covariate matrix is singular. Removing column(s):%s' %
-                    txt)
+                    'Covariate matrix is singular. Removing column(s):{0!s}'.format(
+                    txt))
         mx = X.shape[0]
         if (mx != my):
             raise ValueError(
@@ -919,7 +919,7 @@ class RegLogit(object):
                     tb = tbold - \
                         np.linalg.lstsq(d2l - epsilon * np.eye(d2l.shape), dl)
                     [dev, dl, d2l] = self.loglike(tb, y, X, z, z1)
-                    print('epsilon %g' % epsilon)
+                    print('epsilon {0:g}'.format(epsilon))
                     # end %while
                     # end else
             #[dl, d2l] = logistic_regression_derivatives (X, z, z1, g, g1, p);
@@ -1073,9 +1073,8 @@ class RegLogit(object):
                   '      Pr(>Chi2)')
         # end
 
-        print('Small    %d       %12.4f       %12.4f    %12.4f' %
-              (dfs, devs, localstat, localpvalue))
-        print('Full     %d       %12.4f' % (dfL, devL))
+        print('Small    {0:d}       {1:12.4f}       {2:12.4f}    {3:12.4f}'.format(dfs, devs, localstat, localpvalue))
+        print('Full     {0:d}       {1:12.4f}'.format(dfL, devL))
         print(' ')
 
         return localpvalue
@@ -1097,12 +1096,11 @@ class RegLogit(object):
                   '        Pr(>Chi2)')
         # end
 
-        print('Null     %d       %12.4f       %12.4f    %12.4f' %
-              (self.df_null, self.deviance_null, localstat, localpvalue))
-        print('Full     %d       %12.4f' % (self.df, self.deviance))
+        print('Null     {0:d}       {1:12.4f}       {2:12.4f}    {3:12.4f}'.format(self.df_null, self.deviance_null, localstat, localpvalue))
+        print('Full     {0:d}       {1:12.4f}'.format(self.df, self.deviance))
         print(' ')
 
-        print(' R2 =  %2.4f,     R2adj = %2.4f' % (self.R2, self.R2adj))
+        print(' R2 =  {0:2.4f},     R2adj = {1:2.4f}'.format(self.R2, self.R2adj))
         print(' ')
         return localpvalue
 
@@ -1110,15 +1108,13 @@ class RegLogit(object):
         txtlink = self.link
 
         print('Call:')
-        print('reglogit(formula = %s(Pr(grp(y)<=i)) ~ theta_i+beta*x, family = %s)' %
-            (txtlink, self.family))
+        print('reglogit(formula = {0!s}(Pr(grp(y)<=i)) ~ theta_i+beta*x, family = {1!s})'.format(txtlink, self.family))
         print(' ')
         print('Deviance Residuals:')
         m, q1, me, q3, M = np.percentile(
             self.residualD, q=[0, 25, 50, 75, 100])
         print('    Min       1Q         Median       3Q        Max  ')
-        print('%2.4f     %2.4f     %2.4f     %2.4f     %2.4f' %
-              (m, q1, me, q3, M))
+        print('{0:2.4f}     {1:2.4f}     {2:2.4f}     {3:2.4f}     {4:2.4f}'.format(m, q1, me, q3, M))
         print(' ')
         print(' Coefficients:')
         if False:  # %options.estdispersn
@@ -1132,24 +1128,19 @@ class RegLogit(object):
                       self.params_pvalue)
         for i in range(self.numk):
             print(
-                'theta_%d         %2.4f        %2.4f        %2.4f        %2.4f' %
-                (i, e[i], s[i], z[i], p[i]))
+                'theta_{0:d}         {1:2.4f}        {2:2.4f}        {3:2.4f}        {4:2.4f}'.format(i, e[i], s[i], z[i], p[i]))
 
         for i in range(self.numk, self.numvar):
             print(
-                ' beta_%d         %2.4f        %2.4f        %2.4f        %2.4f\n' %
-                (i - self.numk, e[i], s[i], z[i], p[i]))
+                ' beta_{0:d}         {1:2.4f}        {2:2.4f}        {3:2.4f}        {4:2.4f}\n'.format(i - self.numk, e[i], s[i], z[i], p[i]))
 
         print(' ')
-        print('(Dispersion parameter for %s family taken to be %2.2f)' %
-              (self.family, self.dispersionfit))
+        print('(Dispersion parameter for {0!s} family taken to be {1:2.2f})'.format(self.family, self.dispersionfit))
         print(' ')
         if True:  # %options.constant
-            print('    Null deviance: %2.4f  on %d  degrees of freedom' %
-                  (self.deviance_null, self.df_null))
+            print('    Null deviance: {0:2.4f}  on {1:d}  degrees of freedom'.format(self.deviance_null, self.df_null))
         # end
-        print('Residual deviance: %2.4f  on %d  degrees of freedom' %
-              (self.deviance, self.df))
+        print('Residual deviance: {0:2.4f}  on {1:d}  degrees of freedom'.format(self.deviance, self.df))
 
         self.anode()
 
@@ -1379,7 +1370,7 @@ def test_sklearn():
         svrf = svr_rbf.fit(X, y)
         y_rbf = svrf.predict(X)
         score.append(svrf.score(X, y))
-        pl.plot(X, y_rbf, label='RBF model c=%g' % c)
+        pl.plot(X, y_rbf, label='RBF model c={0:g}'.format(c))
     pl.xlabel('data')
     pl.ylabel('target')
     pl.title('Support Vector Regression')

--- a/wafo/stats/estimation.py
+++ b/wafo/stats/estimation.py
@@ -245,7 +245,7 @@ class Profile(object):
             ['i', 'N', 'alpha', 'pmin', 'pmax', 'x', 'logSF', 'link'],
             [i0, 100, 0.05, None, None, None, None, None])
 
-        self.title = '%g%s CI' % (100 * (1.0 - self.alpha), '%')
+        self.title = '{0:g}{1!s} CI'.format(100 * (1.0 - self.alpha), '%')
         if fit_dist.method.startswith('ml'):
             self.ylabel = self.ylabel + 'likelihood'
             Lmax = fit_dist.LLmax
@@ -291,7 +291,7 @@ class Profile(object):
             self.link = self.fit_dist.dist.link
         if self.profile_par:
             self._local_link = self._par_link
-            self.xlabel = 'phat(%d)' % self.i_fixed
+            self.xlabel = 'phat({0:d})'.format(self.i_fixed)
             p_opt = self._par[self.i_fixed]
         elif self.profile_x:
             self.logSF = fit_dist.logsf(self.x)
@@ -501,8 +501,8 @@ class Profile(object):
         '''
         if alpha < self.alpha:
             warnings.warn(
-                'Might not be able to return CI with alpha less than %g' %
-                self.alpha)
+                'Might not be able to return CI with alpha less than {0:g}'.format(
+                self.alpha))
         cross_level = self.Lmax - 0.5 * chi2isf(alpha, 1)
         ind = findcross(self.data, cross_level)
         N = len(ind)
@@ -741,9 +741,9 @@ class FitDistribution(rv_frozen):
     def __repr__(self):
         params = ['alpha', 'method', 'LLmax', 'LPSmax', 'pvalue',
                   'par', 'par_lower', 'par_upper', 'par_fix', 'par_cov']
-        t = ['%s:\n' % self.__class__.__name__]
+        t = ['{0!s}:\n'.format(self.__class__.__name__)]
         for par in params:
-            t.append('%s = %s\n' % (par, str(getattr(self, par))))
+            t.append('{0!s} = {1!s}\n'.format(par, str(getattr(self, par))))
         return ''.join(t)
 
     def _reduce_func(self, args, kwds):
@@ -751,7 +751,7 @@ class FitDistribution(rv_frozen):
         Nargs = len(args)
         fixedn = []
         index = range(Nargs)
-        names = ['f%d' % n for n in range(Nargs - 2)] + ['floc', 'fscale']
+        names = ['f{0:d}'.format(n) for n in range(Nargs - 2)] + ['floc', 'fscale']
         x0 = args[:]
         for n, key in zip(index[::-1], names[::-1]):
             if key in kwds:
@@ -815,7 +815,7 @@ class FitDistribution(rv_frozen):
                 try:
                     optimizer = getattr(optimize, optimizer)
                 except AttributeError:
-                    raise ValueError("%s is not a valid optimizer" % optimizer)
+                    raise ValueError("{0!s} is not a valid optimizer".format(optimizer))
 
             vals = optimizer(func, x0, args=(ravel(data),), disp=0)
             vals = tuple(vals)
@@ -968,9 +968,9 @@ class FitDistribution(rv_frozen):
                 format1 = ', '.join(['%g'] * numfix)
                 phatistr = format0 % tuple(self.i_fixed)
                 phatvstr = format1 % tuple(self.par[self.i_fixed])
-                fixstr = 'Fixed: phat[%s] = %s ' % (phatistr, phatvstr)
+                fixstr = 'Fixed: phat[{0!s}] = {1!s} '.format(phatistr, phatvstr)
 
-        infostr = 'Fit method: %s, Fit p-value: %2.2f %s' % (
+        infostr = 'Fit method: {0!s}, Fit p-value: {1:2.2f} {2!s}'.format(
             self.method, self.pvalue, fixstr)
         try:
             plotbackend.figtext(0.05, 0.01, infostr)
@@ -991,7 +991,7 @@ class FitDistribution(rv_frozen):
             self.data, SF, symb2, self.data, self.sf(self.data), symb1)
         # plotbackend.plot(self.data,SF,'b.',self.data,self.sf(self.data),'r-')
         plotbackend.xlabel('x')
-        plotbackend.ylabel('F(x) (%s)' % self.dist.name)
+        plotbackend.ylabel('F(x) ({0!s})'.format(self.dist.name))
         plotbackend.title('Empirical SF plot')
 
     def plotecdf(self, symb1='r-', symb2='b.'):
@@ -1007,7 +1007,7 @@ class FitDistribution(rv_frozen):
         plotbackend.plot(self.data, F, symb2,
                          self.data, self.cdf(self.data), symb1)
         plotbackend.xlabel('x')
-        plotbackend.ylabel('F(x) (%s)' % self.dist.name)
+        plotbackend.ylabel('F(x) ({0!s})'.format(self.dist.name))
         plotbackend.title('Empirical CDF plot')
 
     def _get_grid(self, odd=False):
@@ -1059,7 +1059,7 @@ class FitDistribution(rv_frozen):
         ax[3] = min(ymax * 1.3, ax[3])
         plotbackend.axis(ax)
         plotbackend.xlabel('x')
-        plotbackend.ylabel('f(x) (%s)' % self.dist.name)
+        plotbackend.ylabel('f(x) ({0!s})'.format(self.dist.name))
         plotbackend.title('Density plot')
 
     def plotresq(self, symb1='r-', symb2='b.'):
@@ -1076,7 +1076,7 @@ class FitDistribution(rv_frozen):
         y1 = self.data[[0, -1]]
         plotbackend.plot(self.data, y, symb2, y1, y1, symb1)
         plotbackend.xlabel('Empirical')
-        plotbackend.ylabel('Model (%s)' % self.dist.name)
+        plotbackend.ylabel('Model ({0!s})'.format(self.dist.name))
         plotbackend.title('Residual Quantile Plot')
         plotbackend.axis('tight')
         plotbackend.axis('equal')
@@ -1097,7 +1097,7 @@ class FitDistribution(rv_frozen):
         plotbackend.plot(ecdf, mcdf, symb2,
                          p1, p1, symb1)
         plotbackend.xlabel('Empirical')
-        plotbackend.ylabel('Model (%s)' % self.dist.name)
+        plotbackend.ylabel('Model ({0!s})'.format(self.dist.name))
         plotbackend.title('Residual Probability Plot')
         plotbackend.axis('equal')
         plotbackend.axis([0, 1, 0, 1])

--- a/wafo/stats/kde.py
+++ b/wafo/stats/kde.py
@@ -219,7 +219,7 @@ class gaussian_kde(object):
                 points = reshape(points, (self.d, 1))
                 m = 1
             else:
-                msg = "points have dimension %s, dataset has dimension %s" % (d,
+                msg = "points have dimension {0!s}, dataset has dimension {1!s}".format(d,
                     self.d)
                 raise ValueError(msg)
 
@@ -274,9 +274,9 @@ class gaussian_kde(object):
         cov = atleast_2d(cov)
 
         if mean.shape != (self.d,):
-            raise ValueError("mean does not have dimension %s" % self.d)
+            raise ValueError("mean does not have dimension {0!s}".format(self.d))
         if cov.shape != (self.d, self.d):
-            raise ValueError("covariance does not have dimension %s" % self.d)
+            raise ValueError("covariance does not have dimension {0!s}".format(self.d))
 
         # make mean a column vector
         mean = mean[:, newaxis]
@@ -352,8 +352,8 @@ class gaussian_kde(object):
         value, inform = mvn.mvnun(low_bounds, high_bounds, self.dataset,
                                   self.covariance, **extra_kwds)
         if inform:
-            msg = ('An integral in mvn.mvnun requires more points than %s' %
-                   (self.d * 1000))
+            msg = ('An integral in mvn.mvnun requires more points than {0!s}'.format(
+                   (self.d * 1000)))
             warnings.warn(msg)
 
         return value

--- a/wafo/stats/morestats.py
+++ b/wafo/stats/morestats.py
@@ -80,7 +80,7 @@ def bayes_mvs(data, alpha=0.90):
     """
     res = mvsdist(data)
     if alpha >= 1 or alpha <= 0:
-        raise ValueError("0 < alpha < 1 is required, but alpha=%s was given." % alpha)
+        raise ValueError("0 < alpha < 1 is required, but alpha={0!s} was given.".format(alpha))
     return tuple((x.mean(), x.interval(alpha)) for x in res)
 
 
@@ -286,7 +286,7 @@ def _parse_dist_kw(dist, enforce_subclass=True):
         try:
             dist = getattr(distributions, dist)
         except AttributeError:
-            raise ValueError("%s is not a valid distribution name" % dist)
+            raise ValueError("{0!s} is not a valid distribution name".format(dist))
     elif enforce_subclass:
         msg = ("`dist` should be a stats.distributions instance or a string "
               "with the name of such a distribution.")
@@ -447,7 +447,7 @@ def probplot(x, sparams=(), dist='norm', fit=True, plot=None):
         ymax = amax(x)
         posx = xmin + 0.70 * (xmax - xmin)
         posy = ymin + 0.01 * (ymax - ymin)
-        plot.text(posx, posy, "$R^2=%1.4f$" % r)
+        plot.text(posx, posy, "$R^2={0:1.4f}$".format(r))
 
     if fit:
         return (osm, osr), (slope, intercept, r)
@@ -495,7 +495,7 @@ def ppcc_plot(x,a,b,dist='tukeylambda', plot=None, N=80):
         k += 1
     if plot is not None:
         plot.plot(svals, ppcc, 'x')
-        plot.title('(%s) PPCC Plot' % dist)
+        plot.title('({0!s}) PPCC Plot'.format(dist))
         plot.xlabel('Prob Plot Corr. Coef.')
         plot.ylabel('Shape Values')
     return svals, ppcc
@@ -834,7 +834,7 @@ def boxcox_normmax(x, brack=(-2.0, 2.0), method='pearsonr'):
                'mle': _mle,
                'all': _all}
     if method not in methods.keys():
-        raise ValueError("Method %s not recognized." % method)
+        raise ValueError("Method {0!s} not recognized.".format(method))
 
     optimfunc = methods[method]
     return optimfunc(x, brack)
@@ -2176,11 +2176,11 @@ def median_test(*args, **kwds):
     # a zero in the table of expected frequencies.
     rowsums = table.sum(axis=1)
     if rowsums[0] == 0:
-        raise ValueError("All values are below the grand median (%r)." %
-                         grand_median)
+        raise ValueError("All values are below the grand median ({0!r}).".format(
+                         grand_median))
     if rowsums[1] == 0:
-        raise ValueError("All values are above the grand median (%r)." %
-                         grand_median)
+        raise ValueError("All values are above the grand median ({0!r}).".format(
+                         grand_median))
     if ties == "ignore":
         # We already checked that each sample has at least one value, but it
         # is possible that all those values equal the grand median.  If `ties`

--- a/wafo/stats/mstats_basic.py
+++ b/wafo/stats/mstats_basic.py
@@ -665,7 +665,7 @@ def theilslopes(y, x=None, alpha=0.95):
     else:
         x = ma.asarray(x).flatten()
         if len(x) != len(y):
-            raise ValueError("Incompatible lengths ! (%s<>%s)" % (len(y),len(x)))
+            raise ValueError("Incompatible lengths ! ({0!s}<>{1!s})".format(len(y), len(x)))
 
     m = ma.mask_or(ma.getmask(x), ma.getmask(y))
     y._mask = x._mask = m
@@ -1015,10 +1015,10 @@ def trimr(a, limits=None, inclusive=(True, True), axis=None):
     errmsg = "The proportion to cut from the %s should be between 0. and 1."
     if lolim is not None:
         if lolim > 1. or lolim < 0:
-            raise ValueError(errmsg % 'beginning' + "(got %s)" % lolim)
+            raise ValueError(errmsg % 'beginning' + "(got {0!s})".format(lolim))
     if uplim is not None:
         if uplim > 1. or uplim < 0:
-            raise ValueError(errmsg % 'end' + "(got %s)" % uplim)
+            raise ValueError(errmsg % 'end' + "(got {0!s})".format(uplim))
 
     (loinc, upinc) = inclusive
 
@@ -1165,9 +1165,9 @@ def trimmed_mean(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
                  axis=None):
     """Returns the trimmed mean of the data along the given axis.
 
-    %s
+    {0!s}
 
-    """ % trimdoc
+    """.format(trimdoc)
     if (not isinstance(limits,tuple)) and isinstance(limits,float):
         limits = (limits, limits)
     if relative:
@@ -1180,13 +1180,13 @@ def trimmed_var(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
                 axis=None, ddof=0):
     """Returns the trimmed variance of the data along the given axis.
 
-    %s
-    ddof : {0,integer}, optional
+    {0!s}
+    ddof : {{0,integer}}, optional
         Means Delta Degrees of Freedom. The denominator used during computations
         is (n-ddof). DDOF=0 corresponds to a biased estimate, DDOF=1 to an un-
         biased estimate of the variance.
 
-    """ % trimdoc
+    """.format(trimdoc)
     if (not isinstance(limits,tuple)) and isinstance(limits,float):
         limits = (limits, limits)
     if relative:
@@ -1201,13 +1201,13 @@ def trimmed_std(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
                 axis=None, ddof=0):
     """Returns the trimmed standard deviation of the data along the given axis.
 
-    %s
-    ddof : {0,integer}, optional
+    {0!s}
+    ddof : {{0,integer}}, optional
         Means Delta Degrees of Freedom. The denominator used during computations
         is (n-ddof). DDOF=0 corresponds to a biased estimate, DDOF=1 to an un-
         biased estimate of the variance.
 
-    """ % trimdoc
+    """.format(trimdoc)
     if (not isinstance(limits,tuple)) and isinstance(limits,float):
         limits = (limits, limits)
     if relative:
@@ -1279,17 +1279,17 @@ def trimmed_stde(a, limits=(0.1,0.1), inclusive=(1,1), axis=None):
     errmsg = "The proportion to cut from the %s should be between 0. and 1."
     if lolim is not None:
         if lolim > 1. or lolim < 0:
-            raise ValueError(errmsg % 'beginning' + "(got %s)" % lolim)
+            raise ValueError(errmsg % 'beginning' + "(got {0!s})".format(lolim))
     if uplim is not None:
         if uplim > 1. or uplim < 0:
-            raise ValueError(errmsg % 'end' + "(got %s)" % uplim)
+            raise ValueError(errmsg % 'end' + "(got {0!s})".format(uplim))
 
     (loinc, upinc) = inclusive
     if (axis is None):
         return _trimmed_stde_1D(a.ravel(),lolim,uplim,loinc,upinc)
     else:
         if a.ndim > 2:
-            raise ValueError("Array 'a' must be at most two dimensional, but got a.ndim = %d" % a.ndim)
+            raise ValueError("Array 'a' must be at most two dimensional, but got a.ndim = {0:d}".format(a.ndim))
         return ma.apply_along_axis(_trimmed_stde_1D, axis, a,
                                    lolim,uplim,loinc,upinc)
 
@@ -1404,10 +1404,10 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
     errmsg = "The proportion to cut from the %s should be between 0. and 1."
     if lolim is not None:
         if lolim > 1. or lolim < 0:
-            raise ValueError(errmsg % 'beginning' + "(got %s)" % lolim)
+            raise ValueError(errmsg % 'beginning' + "(got {0!s})".format(lolim))
     if uplim is not None:
         if uplim > 1. or uplim < 0:
-            raise ValueError(errmsg % 'end' + "(got %s)" % uplim)
+            raise ValueError(errmsg % 'end' + "(got {0!s})".format(uplim))
 
     (loinc, upinc) = inclusive
 
@@ -1609,8 +1609,8 @@ def kurtosistest(a, axis=0):
             " were given." % np.min(n))
     if np.min(n) < 20:
         warnings.warn(
-            "kurtosistest only valid for n>=20 ... continuing anyway, n=%i" %
-            np.min(n))
+            "kurtosistest only valid for n>=20 ... continuing anyway, n={0:d}".format(
+            np.min(n)))
 
     b2 = kurtosis(a, axis, fisher=False)
     E = 3.0*(n-1) / (n+1)
@@ -2007,7 +2007,7 @@ def friedmanchisquare(*args):
     data = argstoarray(*args).astype(float)
     k = len(data)
     if k < 3:
-        raise ValueError("Less than 3 groups (%i): " % k +
+        raise ValueError("Less than 3 groups ({0:d}): ".format(k) +
                          "the Friedman test is NOT appropriate.")
 
     ranked = ma.masked_values(rankdata(data, axis=0), 0)

--- a/wafo/stats/six.py
+++ b/wafo/stats/six.py
@@ -201,7 +201,7 @@ def remove_move(name):
         try:
             del moves.__dict__[name]
         except KeyError:
-            raise AttributeError("no such move, %r" % (name,))
+            raise AttributeError("no such move, {0!r}".format(name))
 
 
 if PY3:

--- a/wafo/stats/stats.py
+++ b/wafo/stats/stats.py
@@ -1214,8 +1214,8 @@ def kurtosistest(a, axis=0):
             " were given." % int(n))
     if n < 20:
         warnings.warn(
-            "kurtosistest only valid for n>=20 ... continuing anyway, n=%i" %
-            int(n))
+            "kurtosistest only valid for n>=20 ... continuing anyway, n={0:d}".format(
+            int(n)))
     b2 = kurtosis(a, axis, fisher=False)
     E = 3.0*(n-1) / (n+1)
     varb2 = 24.0*n*(n-2)*(n-3) / ((n+1)*(n+1.)*(n+3)*(n+5))
@@ -1687,8 +1687,7 @@ def histogram(a, numbins=10, defaultlimits=None, weights=None, printextras=False
     extrapoints = len([v for v in a
                        if defaultlimits[0] > v or v > defaultlimits[1]])
     if extrapoints > 0 and printextras:
-        warnings.warn("Points outside given histogram range = %s"
-                      % extrapoints)
+        warnings.warn("Points outside given histogram range = {0!s}".format(extrapoints))
     return (hist, defaultlimits[0], binsize, extrapoints)
 
 
@@ -3019,7 +3018,7 @@ def linregress(x, y=None):
             x, y = x.T
         else:
             msg = "If only `x` is given as input, it has to be of shape (2, N) \
-            or (N, 2), provided shape was %s" % str(x.shape)
+            or (N, 2), provided shape was {0!s}".format(str(x.shape))
             raise ValueError(msg)
     else:
         x = asarray(x)
@@ -3137,7 +3136,7 @@ def theilslopes(y, x=None, alpha=0.95):
     else:
         x = np.asarray(x, dtype=float).flatten()
         if len(x) != len(y):
-            raise ValueError("Incompatible lengths ! (%s<>%s)" % (len(y),len(x)))
+            raise ValueError("Incompatible lengths ! ({0!s}<>{1!s})".format(len(y), len(x)))
 
     # Compute sorted slopes only when deltax > 0
     deltax = x[:, np.newaxis] - x

--- a/wafo/stats/tests/common_tests.py
+++ b/wafo/stats/tests/common_tests.py
@@ -40,14 +40,14 @@ def check_moment(distfn, arg, m, v, msg):
                             ' - 1st moment')
     else:                     # or np.isnan(m1),
         npt.assert_(np.isinf(m1),
-               msg + ' - 1st moment -infinite, m1=%s' % str(m1))
+               msg + ' - 1st moment -infinite, m1={0!s}'.format(str(m1)))
 
     if not np.isinf(v):
         npt.assert_almost_equal(m2 - m1 * m1, v, decimal=10, err_msg=msg +
                             ' - 2ndt moment')
     else:                     # or np.isnan(m2),
         npt.assert_(np.isinf(m2),
-               msg + ' - 2nd moment -infinite, m2=%s' % str(m2))
+               msg + ' - 2nd moment -infinite, m2={0!s}'.format(str(m2)))
 
 
 def check_mean_expect(distfn, arg, m, msg):

--- a/wafo/stats/tests/test_continuous_basic.py
+++ b/wafo/stats/tests/test_continuous_basic.py
@@ -242,8 +242,7 @@ def check_sample_mean(sm,v,n, popmean):
     prob = stats.betai(0.5*df, 0.5, df/(df+t*t))
 
     # return t,prob
-    npt.assert_(prob > 0.01, 'mean fail, t,prob = %f, %f, m, sm=%f,%f' %
-            (t, prob, popmean, sm))
+    npt.assert_(prob > 0.01, 'mean fail, t,prob = {0:f}, {1:f}, m, sm={2:f},{3:f}'.format(t, prob, popmean, sm))
 
 
 def check_sample_var(sv,n, popvar):
@@ -251,8 +250,7 @@ def check_sample_var(sv,n, popvar):
     df = n-1
     chi2 = (n-1)*popvar/float(popvar)
     pval = stats.chisqprob(chi2,df)*2
-    npt.assert_(pval > 0.01, 'var fail, t, pval = %f, %f, v, sv=%f, %f' %
-            (chi2,pval,popvar,sv))
+    npt.assert_(pval > 0.01, 'var fail, t, pval = {0:f}, {1:f}, v, sv={2:f}, {3:f}'.format(chi2, pval, popvar, sv))
 
 
 def check_cdf_ppf(distfn,arg,msg):

--- a/wafo/stats/tests/test_distributions.py
+++ b/wafo/stats/tests/test_distributions.py
@@ -46,7 +46,7 @@ dists = ['uniform','norm','lognorm','expon','beta',
 
 def _assert_hasattr(a, b, msg=None):
     if msg is None:
-        msg = '%s does not have attribute %s' % (a, b)
+        msg = '{0!s} does not have attribute {1!s}'.format(a, b)
     assert_(hasattr(a, b), msg=msg)
 
 
@@ -968,7 +968,7 @@ class TestFitMethod(object):
     def test_fit(self):
         def check(func, dist, args, alpha):
             if dist in self.skip:
-                raise SkipTest("%s fit known to fail" % dist)
+                raise SkipTest("{0!s} fit known to fail".format(dist))
             distfunc = getattr(stats, dist)
             with np.errstate(all='ignore'):
                 res = distfunc.rvs(*args, **{'size':200})
@@ -993,7 +993,7 @@ class TestFitMethod(object):
             # Not sure why 'ncf', and 'beta' are failing
             # frechet has different len(args) than distfunc.numargs
             if dist in self.skip + ['frechet']:
-                raise SkipTest("%s fit known to fail" % dist)
+                raise SkipTest("{0!s} fit known to fail".format(dist))
             distfunc = getattr(stats, dist)
             with np.errstate(all='ignore'):
                 res = distfunc.rvs(*args, **{'size':200})

--- a/wafo/stats/tests/test_fit.py
+++ b/wafo/stats/tests/test_fit.py
@@ -63,7 +63,7 @@ def check_cont_fit(distname,arg):
         except:
             pass
         if xfail:
-            msg = "Fitting %s doesn't work reliably yet" % distname
+            msg = "Fitting {0!s} doesn't work reliably yet".format(distname)
             msg += " [Set environment variable SCIPY_XFAIL=1 to run this test nevertheless.]"
             #dec.knownfailureif(True, msg)(lambda: None)()
             options['floc']=0.
@@ -101,10 +101,10 @@ def check_cont_fit(distname,arg):
             if np.all(np.abs(diff) <= diffthreshold):
                 break
     else:
-        txt = 'parameter: %s\n' % str(truearg)
-        txt += 'estimated: %s\n' % str(est)
-        txt += 'diff     : %s\n' % str(diff)
-        raise AssertionError('fit not very good in %s\n' % distfn.name + txt)
+        txt = 'parameter: {0!s}\n'.format(str(truearg))
+        txt += 'estimated: {0!s}\n'.format(str(est))
+        txt += 'diff     : {0!s}\n'.format(str(diff))
+        raise AssertionError('fit not very good in {0!s}\n'.format(distfn.name) + txt)
 
 
 if __name__ == "__main__":

--- a/wafo/stats/tests/test_rank.py
+++ b/wafo/stats/tests/test_rank.py
@@ -134,7 +134,7 @@ class TestRankData(TestCase):
             r = rankdata(data)
             expected_rank = 0.5 * (n + 1)
             assert_array_equal(r, expected_rank * data,
-                               "test failed with n=%d" % n)
+                               "test failed with n={0:d}".format(n))
 
 
 _cases = (

--- a/wafo/stats/tests/test_stats.py
+++ b/wafo/stats/tests/test_stats.py
@@ -2552,10 +2552,10 @@ def test_binomtest():
 
     for p, res in zip(pp,results):
         assert_approx_equal(stats.binom_test(x, n, p), res,
-                            significant=12, err_msg='fail forp=%f' % p)
+                            significant=12, err_msg='fail forp={0:f}'.format(p))
 
     assert_approx_equal(stats.binom_test(50,100,0.1), 5.8320387857343647e-024,
-                            significant=12, err_msg='fail forp=%f' % p)
+                            significant=12, err_msg='fail forp={0:f}'.format(p))
 
 
 def test_binomtest2():

--- a/wafo/stats/twolumps.py
+++ b/wafo/stats/twolumps.py
@@ -295,8 +295,8 @@ class QuickFit(object):
         nparms = max(len(x.parms) for x in distros)
         tcolours = []
         for dd in distros:
-            patch = pl.plot(xx, [dd.pdf(p) for p in xx], label='%10.2f%% %s' % (100.0*dd.rss/dd.dss, dd.name))
-            row = ['', dd.name, '%10.2f%%' % (100.0*dd.rss/dd.dss,)] + ['%0.2f' % x for x in dd.parms]
+            patch = pl.plot(xx, [dd.pdf(p) for p in xx], label='{0:10.2f}% {1!s}'.format(100.0*dd.rss/dd.dss, dd.name))
+            row = ['', dd.name, '{0:10.2f}%'.format(100.0*dd.rss/dd.dss)] + ['{0:0.2f}'.format(x) for x in dd.parms]
             while len(row) < 3 + nparms:
                 row.append('')
             table.append(row)
@@ -305,7 +305,7 @@ class QuickFit(object):
         # add a historgram with the data
         pl.hist(data, bins=bins, normed=True)
         tab = pl.table(cellText=table, cellColours=tcolours,
-                       colLabels=['', 'Distribution', 'Res. SS/Data SS'] + ['P%d' % (x + 1,) for x in range(nparms)],
+                       colLabels=['', 'Distribution', 'Res. SS/Data SS'] + ['P{0:d}'.format(x + 1) for x in range(nparms)],
                        bbox=(0.0, 1.0, 1.0, 0.3))
                  #loc='top'))
         #pl.legend(loc=0)
@@ -323,7 +323,7 @@ class QuickFit(object):
         xx = numpy.linspace(0, 1, n + 2)[1:-1]
         for dd in distros:
 
-            pl.plot(xx, dd.residuals(data), label='%10.2f%% %s' % (100.0*dd.rss/dd.dss, dd.name))
+            pl.plot(xx, dd.residuals(data), label='{0:10.2f}% {1!s}'.format(100.0*dd.rss/dd.dss, dd.name))
         pl.grid(True)
 
     def plot(self, data, topn):

--- a/wafo/tests/test_gaussian.py
+++ b/wafo/tests/test_gaussian.py
@@ -25,7 +25,7 @@ def test_rind():
 
     assert(np.abs(E0 - Et) < err0 + terr0)
 
-    t = 'E0 = %2.6f' % E0
+    t = 'E0 = {0:2.6f}'.format(E0)
     assert(t == 'E0 = 0.001946')
 
     A = np.repeat(Blo, n)
@@ -33,7 +33,7 @@ def test_rind():
     E1, _err1, _terr1 = rind(np.triu(Sc), m, A, B)  # same as E0
     assert(np.abs(E1 - Et) < err0 + terr0)
 
-    t = 'E1 = %2.5f' % E1
+    t = 'E1 = {0:2.5f}'.format(E1)
     assert(t == 'E1 = 0.00195')
 
     # Compute expectation E( abs(X1*X2*...*X5) )
@@ -142,7 +142,7 @@ def test_prbnormnd():
     [val, err, _inform] = prbnormnd(Sc, A, B)
     assert(np.abs(val - Et) < err)
 
-    t = 'val = %2.5f' % val
+    t = 'val = {0:2.5f}'.format(val)
     assert(t == 'val = 0.00195')
 
 

--- a/wafo/tests/test_kdetools.py
+++ b/wafo/tests/test_kdetools.py
@@ -401,7 +401,7 @@ def test_gridcount_4D():
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 if __name__ == '__main__':

--- a/wafo/transform/models.py
+++ b/wafo/transform/models.py
@@ -214,14 +214,14 @@ class TrHermite(TrCommon2):
                 self._x_limit = sa * p(r) + ma
             txt1 = '''
                 The polynomial is not a strictly increasing function.
-                The derivative of g(x) is infinite at x = %g''' % self._x_limit
+                The derivative of g(x) is infinite at x = {0:g}'''.format(self._x_limit)
             warnings.warn(txt1)
         return
 
     def check_forward(self, x):
         if not (self._x_limit is None):
             x00 = self._x_limit
-            txt2 = 'for the given interval x = [%g, %g]' % (x[0], x[-1])
+            txt2 = 'for the given interval x = [{0:g}, {1:g}]'.format(x[0], x[-1])
 
             if any(np.logical_and(x[0] <= x00, x00 <= x[-1])):
                 cdef = 1
@@ -229,10 +229,10 @@ class TrHermite(TrCommon2):
                 cdef = sum(np.logical_xor(x00 <= x[0], x00 <= x[-1]))
 
             if np.mod(cdef, 2):
-                errtxt = 'Unable to invert the polynomial \n %s' % txt2
+                errtxt = 'Unable to invert the polynomial \n {0!s}'.format(txt2)
                 raise ValueError(errtxt)
             np.disp(
-                'However, successfully inverted the polynomial\n %s' % txt2)
+                'However, successfully inverted the polynomial\n {0!s}'.format(txt2))
 
     def _dat2gauss(self, x, *xi):
         if len(xi) > 0:

--- a/wafo/wafodata.py
+++ b/wafo/wafodata.py
@@ -209,7 +209,7 @@ class AxisLabels:
         return self.__str__()
 
     def __str__(self):
-        return '%s\n%s\n%s\n%s\n' % (self.title, self.xlab, self.ylab,
+        return '{0!s}\n{1!s}\n{2!s}\n{3!s}\n'.format(self.title, self.xlab, self.ylab,
                                      self.zlab)
 
     def copy(self):

--- a/wafo/wave_theory/core.py
+++ b/wafo/wave_theory/core.py
@@ -593,7 +593,7 @@ class TransferFunction(object):
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 

--- a/wafo/wave_theory/dispersion_relation.py
+++ b/wafo/wave_theory/dispersion_relation.py
@@ -191,7 +191,7 @@ def w2k(w, theta=0.0, h=inf, g=9.81, count_limit=100):
 
     if count == count_limit:
         warnings.warn('W2K did not converge. The maximum error in the ' +
-                      'last step was: %13.8f' % max(hn[ix]))
+                      'last step was: {0:13.8f}'.format(max(hn[ix])))
 
     k.shape = oshape
 
@@ -202,7 +202,7 @@ def w2k(w, theta=0.0, h=inf, g=9.81, count_limit=100):
 
 def test_docstrings():
     import doctest
-    print('Testing docstrings in %s' % __file__)
+    print('Testing docstrings in {0!s}'.format(__file__))
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
 
 

--- a/wafo/win32_utils.py
+++ b/wafo/win32_utils.py
@@ -161,7 +161,7 @@ class Waitbar(Thread):
                             int(self.position % self.max_val), 0)
                 percentage = int(round(100.0 * self.position / self.max_val))
                 SendMessage(self.dialog, WM_SETTEXT, 0,
-                            self.title + ' (%d%%)' % percentage)
+                            self.title + ' ({0:d}%)'.format(percentage))
     #            SendMessage(self.progbar, PBM_STEPIT, 0, 0)
                 self.do_update = False
             sleep(0.1)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:wafo-project:pywafo?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:wafo-project:pywafo?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)