### PR TITLE
Include all files under wafo/data in installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,8 @@ def setup_package_pyscaffold():
                          include_dirs=['wafo/source/mreg/'],
                          depends=(lib_rindmod_src))
 
+    config.add_data_dir(('data', 'wafo/data'))
+
     needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
     sphinx = ['sphinx'] if needs_sphinx else []
     setup(setup_requires=['six', 'pyscaffold>=2.4rc1,<2.5a0'] + sphinx,


### PR DESCRIPTION
Without this, wafo/data in the installation folder contains only the py files, and the following code gives a FileNotFoundError for wafo/data/sea.dat:
import wafo.data
wafo.data.sea()