### PR TITLE
Increase pyscaffold version to support setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ def setup_package_pyscaffold():
     setup(setup_requires=['six', 'pyscaffold>=2.5.9,<=3.1'] + sphinx,
           tests_require=['pytest_cov', 'pytest'],
           use_pyscaffold=True,
+          packages=setuptools.find_packages(),
           **config.todict())
 
 

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ def setup_package_pyscaffold():
 
     needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
     sphinx = ['sphinx'] if needs_sphinx else []
-    setup(setup_requires=['six', 'pyscaffold>=2.4rc1,<2.5a0'] + sphinx,
+    setup(setup_requires=['six', 'pyscaffold>=2.5.9,<=3.1'] + sphinx,
           tests_require=['pytest_cov', 'pytest'],
           use_pyscaffold=True,
           **config.todict())

--- a/wafo/setup.py
+++ b/wafo/setup.py
@@ -5,14 +5,11 @@ Created on Sun Oct 25 14:55:34 2015
 @author: dave
 """
 
-
-def configuration(parent_package='', top_path=None):
-    from numpy.distutils.misc_util import Configuration
-    config = Configuration('wafo', parent_package, top_path)
-    config.add_subpackage('source')
-    config.make_config_py()
-    return config
-
 if __name__ == "__main__":
-    from numpy.distutils.core import setup
-    setup(**configuration(top_path='').todict())
+    from setuptools import setup, find_packages
+        setup(
+            name = 'wafo',
+            packages = find_packages(),
+            no-vcs = 1,
+            format = 'bdist_wheel'
+        )


### PR DESCRIPTION
Older pyscaffold versions are not compatible with setuptools>=38, so pywafo cannot install. I tested on pyscaffold versions 2.5.9 and 3.1 (latest), so have set those as the limits.