### PR TITLE
Fix import pade for scipy>=1.0.0

### DIFF
--- a/wafo/polynomial.py
+++ b/wafo/polynomial.py
@@ -26,7 +26,10 @@ import numpy as np
 from numpy import (newaxis, arange, pi)
 from scipy.fftpack import dct, idct as _idct
 from numpy.lib.polynomial import *  # @UnusedWildImport
-from scipy.misc import pade  # @UnresolvedImport
+try:
+    from scipy.interpolate import pade
+except ImportError:
+    from scipy.misc import pade  # @UnresolvedImport
 __all__ = np.lib.polynomial.__all__
 __all__ = __all__ + ['pade', 'padefit', 'polyreloc', 'polyrescl', 'polytrim',
                      'poly2hstr', 'poly2str', 'polyshift', 'polyishift',

--- a/wafo/polynomial.py
+++ b/wafo/polynomial.py
@@ -27,7 +27,7 @@ from numpy import (newaxis, arange, pi)
 from scipy.fftpack import dct, idct as _idct
 from numpy.lib.polynomial import *  # @UnusedWildImport
 try:
-    from scipy.interpolate import pade
+    from scipy.interpolate import pade  # pade has moved to scipy.interpolate in scipy 1.0.0
 except ImportError:
     from scipy.misc import pade  # @UnresolvedImport
 __all__ = np.lib.polynomial.__all__


### PR DESCRIPTION
pade has moved to scipy.interpolate in scipy 1.0.0, both imports kept to not break for scipy<1