### PR TITLE
Fix import logsumexp for scipy>=1.0.0

### DIFF
--- a/wafo/stats/_discrete_distns.py
+++ b/wafo/stats/_discrete_distns.py
@@ -7,7 +7,7 @@ from __future__ import division, print_function, absolute_import
 from scipy import special
 from scipy.special import entr, gammaln as gamln
 try:
-    from scipy.special import logsumexp
+    from scipy.special import logsumexp  # logsumexp has moved to scipy.special in scipy 1.0.0
 except ImportError:
     from scipy.misc import logsumexp
 

--- a/wafo/stats/_discrete_distns.py
+++ b/wafo/stats/_discrete_distns.py
@@ -6,7 +6,10 @@ from __future__ import division, print_function, absolute_import
 
 from scipy import special
 from scipy.special import entr, gammaln as gamln
-from scipy.misc import logsumexp
+try:
+    from scipy.special import logsumexp
+except ImportError:
+    from scipy.misc import logsumexp
 
 from numpy import floor, ceil, log, exp, sqrt, log1p, expm1, tanh, cosh, sinh
 


### PR DESCRIPTION
logsumexp has moved to scipy.special in scipy 1.0.0, both imports kept to not break for scipy<1