### PR TITLE
Add wafo\.libs to the DLL search path

### DIFF
--- a/src/wafo/__init__.py
+++ b/src/wafo/__init__.py
@@ -1,3 +1,12 @@
+import os
+_dll_dir = os.path.join(os.path.dirname(__file__), '.libs')
+if os.path.isdir(_dll_dir):
+    try:
+        os.add_dll_directory(_dll_dir)
+    except AttributeError:
+        pass
+    os.environ['PATH'] += os.pathsep + _dll_dir
+
 from .info import __doc__
 
 from . import misc


### PR DESCRIPTION
The compiled Fortran extensions are placed in wafo\.libs as dll files while corresponding pyd files are in the wafo root. For the pyd files to be able to locate the dlls on import we need to add their path with os.add_dll_directory(path) which is the supported way since Python 3.8. However, for me that method only works in Python 3.10. To make it work for Python<3.10, wafo\.libs is also added to the PATH environment variable. Tested on Windows 10 with Python 3.6 up to 3.10.