### PR TITLE
Deprecations warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-10.15]
       fail-fast: false
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-six
 numpy>=1.19
 numdifftools>=0.2
 scipy>=1.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,10 @@ addopts =
 #    --verbose
 #    --doctest-modules
 #    --pep8
+filterwarnings =
+    error
+    ignore::UserWarning
+    ignore::RuntimeWarning
 
 norecursedirs =
     .*

--- a/src/wafo/covariance/core.py
+++ b/src/wafo/covariance/core.py
@@ -30,7 +30,7 @@ from ..containers import PlotData
 from ..misc import sub_dict_select, nextpow2  # , JITImport
 from .. import spectrum as _wafospec
 from scipy.sparse.linalg import spsolve
-from scipy.sparse.base import issparse
+from scipy.sparse import issparse
 from scipy.signal.windows import parzen
 # _wafospec = JITImport('wafo.spectrum')
 

--- a/src/wafo/integrate_oscillating.py
+++ b/src/wafo/integrate_oscillating.py
@@ -112,7 +112,7 @@ def evans_webster_weights(omega, g, d_g, x, basis, *args, **kwds):
         rhs[k] = basis(1, k) * b_1 - basis(-1, k) * a_1
         a_matrix[k] = (dbasis(x, k, n=1) + j_w * lim_psi(x, k))
 
-    solution = linalg.lstsq(a_matrix, rhs, rcond=None)
+    solution = linalg.lstsq(a_matrix, rhs, rcond=-1)
     return solution[0]
 
 
@@ -400,7 +400,7 @@ class AdaptiveLevin(_Integrator):
             warnings.warn('Singularities detected! ')
             a_matrix[k1] = 0
             rhs[k1] = 0
-        solution = linalg.lstsq(a_matrix, rhs)
+        solution = linalg.lstsq(a_matrix, rhs, rcond=-1)
         v = basis.eval([-1, 1], solution[0])
 
         lim_g = Limit(g)

--- a/src/wafo/interpolate.py
+++ b/src/wafo/interpolate.py
@@ -617,7 +617,7 @@ class SmoothSpline(PPform):
 
         szy = y.shape
 
-        nd = np.int(prod(szy[:-1]))
+        nd = np.int64(prod(szy[:-1]))
         ny = szy[-1]
 
         self._check(dx, n, ny)

--- a/src/wafo/kdetools/kdetools.py
+++ b/src/wafo/kdetools/kdetools.py
@@ -27,9 +27,9 @@ from wafo.kdetools.gridding import gridcount
 
 __all__ = ['TKDE', 'KDE', 'test_docstrings', 'KRegression', 'BKRegression']
 
-_TINY = np.finfo(float).machar.tiny
-# _REALMIN = np.finfo(float).machar.xmin
-_REALMAX = np.finfo(float).machar.xmax
+_TINY = np.finfo(float).tiny
+# _REALMIN = np.finfo(float).machar.min
+_REALMAX = np.finfo(float).max
 _EPS = np.finfo(float).eps
 
 

--- a/src/wafo/kdetools/kernels.py
+++ b/src/wafo/kdetools/kernels.py
@@ -15,7 +15,6 @@ from wafo.misc import tranproc  # , trangood
 from wafo.kdetools.gridding import gridcount
 from wafo.dctpack import dct
 from wafo.testing import test_docstrings
-from six import with_metaclass
 
 __all__ = ['Kernel', 'sphere_volume', 'qlevels', 'iqrange', 'percentile']
 
@@ -260,7 +259,8 @@ def sphere_volume(d, r=1.0):
     return (r ** d) * 2.0 * pi ** (d / 2.0) / (d * gamma(d / 2.0))
 
 
-class _Kernel(with_metaclass(ABCMeta)):
+class _Kernel(object):
+    __metaclass__ = ABCMeta
 
     def __init__(self, r=1.0, stats=None, name=''):
         self.r = r  # radius of effective support of kernel

--- a/src/wafo/misc.py
+++ b/src/wafo/misc.py
@@ -1580,7 +1580,7 @@ def findtc(x_in, v=None, kind=None):
     n_tc = int((n_c - 1 - is_even) / 2)
 
     # allocate variables before the loop increases the speed
-    ind = zeros(n_c - 1, dtype=np.int)
+    ind = zeros(n_c - 1, dtype=int)
 
     first_is_down_crossing = (x[v_ind[0]] > x[v_ind[0] + 1])
     if first_is_down_crossing:

--- a/src/wafo/sg_filter/_core.py
+++ b/src/wafo/sg_filter/_core.py
@@ -5,7 +5,7 @@ from scipy.sparse.linalg import spsolve
 import scipy.optimize as optimize
 from scipy.signal import _savitzky_golay
 from scipy.ndimage import convolve1d
-from scipy.ndimage.morphology import distance_transform_edt
+from scipy.ndimage import distance_transform_edt
 import warnings
 from wafo.dctpack import dctn, idctn
 
@@ -167,7 +167,7 @@ class SavitzkyGolay(object):
         return self.smooth(signal)
 
     def smooth(self, signal):
-        dtype = np.result_type(signal, np.float)
+        dtype = np.result_type(signal, float)
         x = np.asarray(signal, dtype=dtype)
 
         coeffs = self._coeff

--- a/src/wafo/sg_filter/tests/test_sg_filter.py
+++ b/src/wafo/sg_filter/tests/test_sg_filter.py
@@ -59,10 +59,10 @@ class Test(unittest.TestCase):
         # print(', '.join(['{0:d}'.format(yj) for yj in y]))
         # print(', '.join(['{0:d}'.format(int(yj)) for yj in yy2]))
 
-        self.assert_(sum(res['outliers'] == True) == 76)
+        self.assertTrue(sum(res['outliers'] == True) == 76)
         valid_names = set(('Y0', 'outliers', 'LB', 'ADX', 'UB'))
         for name in res:
-            self.assert_(name in valid_names)
+            self.assertTrue(name in valid_names)
         assert_array_almost_equal(yy[outliers], [5002, 5000, 5003, 5008, 5000,
                                                  4997, 4998, 4999, 5009, 4997])
 

--- a/src/wafo/spectrum/core.py
+++ b/src/wafo/spectrum/core.py
@@ -12,7 +12,7 @@ from scipy.integrate import simps, trapz
 from scipy.special import erf
 from scipy.linalg import toeplitz
 import scipy.interpolate as interpolate
-from scipy.interpolate.interpolate import interp1d, interp2d
+from scipy.interpolate import interp1d, interp2d
 from wafo.objects import TimeSeries, mat2timeseries
 from wafo.interpolate import stineman_interp
 from wafo.wave_theory.dispersion_relation import w2k  # , k2w
@@ -1904,7 +1904,7 @@ class SpecData1D(PlotData):
          There are 3 (NI=4) regions with constant barriers:
          (indI[0]=0);   for i in (indI[0],indI[1]]    Y[i]<0.
          (indI[1]=Nt);  for i in (indI[1]+1,indI[2]], Y[i]<0 (deriv. X''(t1))
-         (indI[2]=Nt+1);  for i\in (indI[2]+1,indI[3]], Y[i]>0 (deriv. X''(tn))
+         (indI[2]=Nt+1);  for i in (indI[2]+1,indI[3]], Y[i]>0 (deriv. X''(tn))
 
          For DEF = 4,5 (Level v separated Maxima and Minima and
                         period/wavelength from Max to crossing)
@@ -1926,10 +1926,10 @@ class SpecData1D(PlotData):
          Xc =    "     Nc    variables to condition on
 
          There are 4 (NI=5) regions with constant barriers:
-         (indI(1)=0);     for i\in (indI(1),indI(2)]    Y(i)<0.
-         (indI(2)=Nt)  ;  for i\in (indI(2)+1,indI(3)], Y(i)<0 (deriv. X''(t1))
-         (indI(3)=Nt+1);  for i\in (indI(3)+1,indI(4)], Y(i)>0 (deriv. X''(tn))
-         (indI(4)=Nt+2);  for i\in (indI(4)+1,indI(5)], Y(i)<0 (deriv. X'(ts))
+         (indI(1)=0);     for i in (indI(1),indI(2)]    Y(i)<0.
+         (indI(2)=Nt)  ;  for i in (indI(2)+1,indI(3)], Y(i)<0 (deriv. X''(t1))
+         (indI(3)=Nt+1);  for i in (indI(3)+1,indI(4)], Y(i)>0 (deriv. X''(tn))
+         (indI(4)=Nt+2);  for i in (indI(4)+1,indI(5)], Y(i)<0 (deriv. X'(ts))
         '''
         R0, R2, R4 = R[:, :5:2].T
         covinput = self._covinput_mmt_pdf

--- a/src/wafo/spectrum/tests/test_specdata1d.py
+++ b/src/wafo/spectrum/tests/test_specdata1d.py
@@ -152,7 +152,7 @@ class TestSpectrumHs5(unittest.TestCase):
         ch, R, txt = S.characteristic(1)
         assert_array_almost_equal(ch, 8.59007646)
         assert_array_almost_equal(R,  0.03040216)
-        self.assert_(txt == ['Tm01'])
+        self.assertTrue(txt == ['Tm01'])
 
         ch, R, txt = S.characteristic([1, 2, 3])  # fact a vector of integers
         assert_array_almost_equal(ch, [8.59007646,  8.03139757,  5.62484314])

--- a/src/wafo/stats/distributions.py
+++ b/src/wafo/stats/distributions.py
@@ -17,7 +17,7 @@ from scipy.stats._constants import _EULER
 import scipy.special as sc
 import numpy as np
 from scipy import optimize
-from scipy.stats.mstats_basic import mode
+from scipy.stats import mode
 
 
 def _betaprime_fitstart(self, data, fitstart):  # pab

--- a/src/wafo/stats/estimation.py
+++ b/src/wafo/stats/estimation.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from wafo.plotbackend import plotbackend
 from wafo.misc import ecross, findcross
-# from scipy._lib.six import string_types
 import numdifftools as nd  # @UnresolvedImport
 
 
@@ -1301,7 +1300,7 @@ class FitDistribution(rv_frozen):
         """Compute covariance
         """
 
-        hessian = np.asmatrix(self._hessian(self._fitfun, par, self.data))
+        hessian = self._hessian(self._fitfun, par, self.data)
         # hessian = -nd.Hessian(lambda par: self._fitfun(par, self.data),
         #                 method='forward')(self.par)
         self.hessian = hessian

--- a/src/wafo/tests/test_integrate.py
+++ b/src/wafo/tests/test_integrate.py
@@ -14,13 +14,13 @@ class TestIntegrators(unittest.TestCase):
     def test_clencurt(self):
         val, err = clencurt(np.exp, 0, 2)
         assert_array_almost_equal(val, np.expm1(2))
-        self.assert_(err < 1e-10)
+        self.assertTrue(err < 1e-10)
 
     def test_romberg(self):
         tol = 1e-7
         q, err = romberg(np.sqrt, 0, 10, 0, abseps=tol)
         assert_array_almost_equal(q, 2.0/3 * 10**(3./2))
-        self.assert_(err < tol)
+        self.assertTrue(err < tol)
 
 
 class TestGaussq(unittest.TestCase):
@@ -78,30 +78,30 @@ class TestQuadgr(unittest.TestCase):
     def test_log(self):
         Q, err = quadgr(np.log, 0, 1)
         assert_array_almost_equal(Q, -1)
-        self.assert_(err < 1e-5)
+        self.assertTrue(err < 1e-5)
 
     def test_exp(self):
         Q, err = quadgr(np.exp, 0, 9999*1j*np.pi)
         assert_array_almost_equal(Q, -2.0000000000122662)
-        self.assert_(err < 1.0e-8)
+        self.assertTrue(err < 1.0e-8)
 
     def test_integral3(self):
         tol = 1e-12
         Q, err = quadgr(lambda x: np.sqrt(4-x**2), 0, 2, tol)
         assert_array_almost_equal(Q, np.pi)
-        self.assert_(err < tol)
+        self.assertTrue(err < tol)
         # (3.1415926535897811, 1.5809575870662229e-13)
 
     def test_integral4(self):
         Q, err = quadgr(lambda x: 1./x**0.75, 0, 1)
         assert_array_almost_equal(Q, 4)
-        self.assert_(err < 1.0e-12)
+        self.assertTrue(err < 1.0e-12)
 
     def test_integrand4(self):
         tol = 1e-10
         Q, err = quadgr(lambda x: 1./np.sqrt(1-x**2), -1, 1, tol)
         assert_array_almost_equal(Q, np.pi)
-        self.assert_(err < tol)
+        self.assertTrue(err < tol)
         # (3.141596056985029, 6.2146261559092864e-06)
 
     def test_integrand5(self):
@@ -109,14 +109,14 @@ class TestQuadgr(unittest.TestCase):
         Q, err = quadgr(lambda x: np.exp(-x**2), -np.inf, np.inf, tol)
 
         assert_array_almost_equal(Q, np.sqrt(np.pi))
-        self.assert_(err < tol)
+        self.assertTrue(err < tol)
         # (1.7724538509055152, 1.9722334876348668e-11)
 
     def test_integrand6(self):
         tol = 1e-9
         Q, err = quadgr(lambda x: np.cos(x) * np.exp(-x), 0, np.inf, tol)
         assert_array_almost_equal(Q, 0.5)
-        self.assert_(err < tol)
+        self.assertTrue(err < tol)
         # (0.50000000000000044, 7.3296813063450372e-11)
 
 if __name__ == "__main__":

--- a/src/wafo/tests/test_integrate_oscillating.py
+++ b/src/wafo/tests/test_integrate_oscillating.py
@@ -106,7 +106,7 @@ class LevinQuadrature(unittest.TestCase):
             quad = quadfun(f, g, dg,  a=a, b=b, full_output=True)
             val, info = quad(omega)
             assert_allclose(val, true_val)
-            self.assert_(info.error_estimate < 1e-11)
+            self.assertTrue(info.error_estimate < 1e-11)
             # assert_allclose(info.n, 9)
 
     def test_exp_jw_t(self):
@@ -130,7 +130,7 @@ class LevinQuadrature(unittest.TestCase):
             val, info = quad(omega)
 
             assert_allclose(val, true_val)
-            self.assert_(info.error_estimate < 1e-12)
+            self.assertTrue(info.error_estimate < 1e-12)
             # assert_allclose(info.n, 21)
 
     def test_I1_1_p_ln_x_exp_jw_xlnx(self):
@@ -153,7 +153,7 @@ class LevinQuadrature(unittest.TestCase):
             val, info = quad(omega)
 
             assert_allclose(val, true_val)
-            self.assert_(info.error_estimate < 1e-10)
+            self.assertTrue(info.error_estimate < 1e-10)
             # assert_allclose(info.n, 11)
 
     def test_I4_ln_x_exp_jw_30x(self):
@@ -183,7 +183,7 @@ class LevinQuadrature(unittest.TestCase):
             quad = quadfun(f, g, dg, a, b, full_output=True)
             val, info = quad(omega)
             assert_allclose(val, true_val)
-            self.assert_(info.error_estimate < 1e-5)
+            self.assertTrue(info.error_estimate < 1e-5)
 
     def test_I5_coscost_sint_exp_jw_sint(self):
         a = 0
@@ -213,7 +213,7 @@ class LevinQuadrature(unittest.TestCase):
             val, info = quad(omega)
 
             assert_allclose(val, true_val)
-            self.assert_(info.error_estimate < 1e-9)
+            self.assertTrue(info.error_estimate < 1e-9)
 
     def test_I6_exp_jw_td_1_m_t(self):
         a = 0
@@ -240,7 +240,7 @@ class LevinQuadrature(unittest.TestCase):
             val, info = quad(omega)
 
             assert_allclose(val, true_val)
-            self.assert_(info.error_estimate < 1e-10)
+            self.assertTrue(info.error_estimate < 1e-10)
 
     def test_I8_cos_47pix2d4_exp_jw_x(self):
         def f(t):
@@ -264,7 +264,7 @@ class LevinQuadrature(unittest.TestCase):
             val, _info = quad(omega)
             assert_allclose(val.real, true_val)
             s = 1 if s <= 2 else s // 2
-            # self.assert_(info.error_estimate < 1e-10)
+            # self.assertTrue(info.error_estimate < 1e-10)
             # assert_allclose(info.n, 11)
 
     def test_I9_exp_tant_sec2t_exp_jw_tant(self):
@@ -289,7 +289,7 @@ class LevinQuadrature(unittest.TestCase):
             val, info = quad(omega)
 
             assert_allclose(val, true_val)
-            self.assert_(info.error_estimate < 1e-8)
+            self.assertTrue(info.error_estimate < 1e-8)
 
     def test_exp_zdcos2t_dcos2t_exp_jw_cos_t_b_dcos2t(self):
         x1 = 20

--- a/src/wafo/tests/test_objects.py
+++ b/src/wafo/tests/test_objects.py
@@ -6,7 +6,7 @@ Created on 5. aug. 2010
 """
 
 import unittest
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 import wafo.data
 import wafo.objects as wo
 import wafo.spectrum.models as sm


### PR DESCRIPTION
In this PR:
- remove six, this library is Python 3 only for a while
- remove all Deprecation, Future, and PendingDeprecation warnings that would become errors in the near future as libraries are updated
- turn all warnings but RuntimeWarnings and UserWarnings into errors in the CIs.